### PR TITLE
Set default 'Pendiente' status for new maintenance and service orders

### DIFF
--- a/alter_default_estatus.php
+++ b/alter_default_estatus.php
@@ -1,0 +1,14 @@
+<?php
+include 'conexion.php';
+
+$tables = ['ordenes_mantenimiento', 'ordenes_servicio_cliente'];
+
+foreach ($tables as $table) {
+    $sql = "ALTER TABLE $table MODIFY estatus ENUM('Pendiente', 'En proceso', 'Terminado', 'Cancelado') DEFAULT 'Pendiente'";
+    if ($conn->query($sql) === TRUE) {
+        echo "Tabla $table modificada\n";
+    } else {
+        echo "Error actualizando $table: " . $conn->error . "\n";
+    }
+}
+?>

--- a/ordenes_mantenimiento.php
+++ b/ordenes_mantenimiento.php
@@ -43,7 +43,7 @@ if (isset($_GET['modal'])) {
     <div class="mb-3">
         <label for="estatus" class="form-label">Estatus</label>
         <select name="estatus" class="form-control" required>
-            <option value="Pendiente">Pendiente</option>
+            <option value="Pendiente" selected>Pendiente</option>
             <option value="En proceso">En proceso</option>
             <option value="Terminado">Terminado</option>
         </select>

--- a/ordenes_servicio_cliente.php
+++ b/ordenes_servicio_cliente.php
@@ -42,7 +42,7 @@ if (isset($_GET['modal'])) {
     <div class="mb-3">
         <label for="estatus" class="form-label">Estatus</label>
         <select name="estatus" class="form-control" required>
-            <option value="Pendiente">Pendiente</option>
+            <option value="Pendiente" selected>Pendiente</option>
             <option value="En proceso">En proceso</option>
             <option value="Terminado">Terminado</option>
             <option value="Cancelado">Cancelado</option>

--- a/procesar_mantenimiento.php
+++ b/procesar_mantenimiento.php
@@ -5,7 +5,7 @@ include 'conexion.php'; // Conexión centralizada
 $alojamiento_id = $_POST['alojamiento_id'] ?? '';
 $descripcion = $_POST['descripcion_reporte'] ?? '';
 $fecha_reporte = $_POST['fecha_reporte'] ?? '';
-$estatus = $_POST['estatus'] ?? 'Pendiente';
+$estatus = isset($_POST['estatus']) && trim($_POST['estatus']) !== '' ? $_POST['estatus'] : 'Pendiente';
 $usuario_id = $_POST['usuario_solicitante_id'] ?? '';
 $unidad_id = $_POST['unidad_negocio_id'] ?? '';
 $notas = $_POST['notas'] ?? '';

--- a/procesar_servicio_cliente.php
+++ b/procesar_servicio_cliente.php
@@ -5,7 +5,7 @@ include 'conexion.php'; // Conexión centralizada
 $alojamiento_id = $_POST['alojamiento_id'] ?? '';
 $descripcion = $_POST['descripcion_reporte'] ?? '';
 $fecha_reporte = $_POST['fecha_reporte'] ?? '';
-$estatus = $_POST['estatus'] ?? 'Pendiente';
+$estatus = isset($_POST['estatus']) && trim($_POST['estatus']) !== '' ? $_POST['estatus'] : 'Pendiente';
 $usuario_id = $_POST['usuario_solicitante_id'] ?? '';
 $unidad_id = $_POST['unidad_negocio_id'] ?? '';
 $notas = $_POST['notas'] ?? '';

--- a/reporte_camarista.php
+++ b/reporte_camarista.php
@@ -54,7 +54,7 @@ include 'conexion.php';
             <div class="mb-3">
                 <label for="estatus" class="form-label">Estatus</label>
                 <select name="estatus" class="form-control" required>
-                    <option value="Pendiente">Pendiente</option>
+                    <option value="Pendiente" selected>Pendiente</option>
                     <option value="En proceso">En proceso</option>
                     <option value="Terminado">Terminado</option>
                     <option value="Cancelado">Cancelado</option>


### PR DESCRIPTION
## Summary
- default status 'Pendiente' if status field left blank
- mark `Pendiente` as the selected option in order forms
- PHP script to alter tables so `estatus` defaults to `Pendiente`

## Testing
- `php -l procesar_mantenimiento.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847276757208332b600488b1cfe6ad2