### PR TITLE
Add multiple puesto support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ The application expects a MySQL database configured in `conexion.php`. Tables su
 - **Mantenimiento**: existing module for maintenance requests.
 - **Servicio al Cliente**: duplicated from maintenance, adjusted for customer service requests. Only roles *servicio al cliente*, *gerente* and *admin* can use it.
 
+## Puestos Múltiples
+`editar_usuario.php` permite ingresar más de un puesto separado por comas (por ejemplo: `"Servicio al Cliente, Mantenimiento"`).
+En `menu_principal.php` se evalúan esos puestos para mostrar los módulos correspondientes.
+
 ## KPIs
 Each module has export options to CSV/PDF and printable views. Charts are generated with Chart.js.
 

--- a/create_tables.php
+++ b/create_tables.php
@@ -30,7 +30,8 @@ CREATE TABLE IF NOT EXISTS usuarios (
     nombre VARCHAR(255) NOT NULL,
     telefono VARCHAR(20),
     email VARCHAR(255),
-    puesto VARCHAR(100)
+    -- Permitir guardar multiples puestos separados por coma
+    puesto TEXT
 );
 ");
 

--- a/menu_principal.php
+++ b/menu_principal.php
@@ -6,6 +6,12 @@ include 'verificar_acceso.php'; // << Reemplaza config y funciones auxiliares
 
 // Redirección automática según el puesto (si aplica)
 redireccionar_por_puesto(obtener_puesto());
+
+// Permite evaluar varios puestos separados por coma
+function tienePuesto($puesto) {
+    $lista = array_map('trim', explode(',', strtolower($_SESSION['puesto'] ?? '')));
+    return in_array(strtolower($puesto), $lista);
+}
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -61,7 +67,7 @@ redireccionar_por_puesto(obtener_puesto());
                 </div>
             <?php endif; ?>
 
-<?php if (puede_ver_modulo('mantenimiento') || puede_ver_modulo('mantenimiento_listado')): ?>
+            <?php if (tienePuesto('mantenimiento')): ?>
                 <div class="col-12 col-md-4">
                     <div class="modulo-box">
                         <a href="minipanel_mantenimiento.php">
@@ -72,7 +78,7 @@ redireccionar_por_puesto(obtener_puesto());
                 </div>
             <?php endif; ?>
 
-            <?php if (puede_ver_modulo('servicio_cliente')): ?>
+            <?php if (tienePuesto('servicio al cliente')): ?>
                 <div class="col-12 col-md-4">
                     <div class="modulo-box">
                         <a href="minipanel_servicio_cliente.php">


### PR DESCRIPTION
## Summary
- allow comma-separated puestos by making puesto field TEXT
- add `tienePuesto()` helper in `menu_principal.php`
- display maintenance and customer service modules based on puestos
- document multi puesto usage in README

## Testing
- `php -l create_tables.php`
- `php -l menu_principal.php`


------
https://chatgpt.com/codex/tasks/task_e_68472b13e03c8332921b7f555e21b292