### PR TITLE
Implement dynamic role-based module access

### DIFF
--- a/acceso_denegado.php
+++ b/acceso_denegado.php
@@ -1,0 +1,18 @@
+<?php
+session_start();
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Acceso Denegado</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container mt-5 text-center">
+        <h3 class="text-danger">Acceso denegado</h3>
+        <p>No cuentas con permisos para ver esta sección.</p>
+        <a href="menu_principal.php" class="btn btn-primary">Regresar al menú</a>
+    </div>
+</body>
+</html>

--- a/login.php
+++ b/login.php
@@ -6,12 +6,13 @@ $username = "corazon_caribe";
 $password = "Kantun.01*";
 $database = "corazon_orderdecompras";
 
-// Crear conexi贸n
+// Crear conexi脙鲁n
 $conn = new mysqli($servername, $username, $password, $database);
 
-// Revisar conexi贸n
+        $_SESSION['rol'] = $user['rol']; // Alias para compatibilidad
+// Revisar conexi脙鲁n
 if ($conn->connect_error) {
-    die("Conexi贸n fallida: " . $conn->connect_error);
+    die("Conexi脙鲁n fallida: " . $conn->connect_error);
 }
 
 // Obtener datos del formulario
@@ -27,14 +28,14 @@ $result = $stmt->get_result();
 
 if ($result->num_rows === 1) {
     $user = $result->fetch_assoc();
-    // Verificar contrase帽a
+    // Verificar contrase脙卤a
 
 if ($password === $user['password']) {
 
         $_SESSION['user_id'] = $user['id'];
         $_SESSION['user_name'] = $user['nombre'];
         $_SESSION['user_role'] = $user['rol']; // Almacena el rol del usuario
-        $_SESSION['puesto'] = $user['puesto']; // ⚠️ este es el que falta
+        $_SESSION['puesto'] = $user['puesto']; // 聛7虏2鈥�1鈥�5 este es el que falta
         header("Location: menu_principal.php");
         echo "<pre>";
 print_r($_SESSION);

--- a/menu_principal.php
+++ b/menu_principal.php
@@ -7,10 +7,28 @@ include 'verificar_acceso.php'; // << Reemplaza config y funciones auxiliares
 // Redirección automática según el puesto (si aplica)
 redireccionar_por_puesto(obtener_puesto());
 
-// Permite evaluar varios puestos separados por coma
-function tienePuesto($puesto) {
-    $lista = array_map('trim', explode(',', strtolower($_SESSION['puesto'] ?? '')));
-    return in_array(strtolower($puesto), $lista);
+$rol = $_SESSION['rol'] ?? ($_SESSION['user_role'] ?? '');
+
+function verModulo($modulo) {
+    global $rol;
+    $ver_todo = ['Administrador', 'Gerente', 'Superadmin', 'CEO', 'Webmaster'];
+    $ver_mantenimiento = ['Servicio al Cliente', 'Camarista', 'Ama de Llaves'];
+
+    switch ($modulo) {
+        case 'mantenimiento':
+            return in_array($rol, array_merge($ver_todo, $ver_mantenimiento));
+        case 'servicio_cliente':
+            return in_array($rol, array_merge(['Servicio al Cliente'], $ver_todo));
+        case 'kpis':
+        case 'ordenes_compra':
+        case 'configuracion':
+        case 'usuarios':
+            return in_array($rol, $ver_todo);
+        case 'camarista':
+            return in_array($rol, ['Camarista', 'Ama de Llaves']);
+        default:
+            return false;
+    }
 }
 ?>
 <!DOCTYPE html>
@@ -56,7 +74,7 @@ function tienePuesto($puesto) {
 
         <div class="row justify-content-center g-4">
 
-            <?php if (puede_ver_modulo('compras')): ?>
+            <?php if (verModulo('ordenes_compra')): ?>
                 <div class="col-12 col-md-4">
                     <div class="modulo-box">
                         <a href="minipanel.php">
@@ -67,7 +85,7 @@ function tienePuesto($puesto) {
                 </div>
             <?php endif; ?>
 
-            <?php if (tienePuesto('mantenimiento')): ?>
+            <?php if (verModulo('mantenimiento')): ?>
                 <div class="col-12 col-md-4">
                     <div class="modulo-box">
                         <a href="minipanel_mantenimiento.php">
@@ -78,7 +96,7 @@ function tienePuesto($puesto) {
                 </div>
             <?php endif; ?>
 
-            <?php if (tienePuesto('servicio al cliente')): ?>
+            <?php if (verModulo('servicio_cliente')): ?>
                 <div class="col-12 col-md-4">
                     <div class="modulo-box">
                         <a href="minipanel_servicio_cliente.php">
@@ -89,7 +107,7 @@ function tienePuesto($puesto) {
                 </div>
             <?php endif; ?>
 
-            <?php if (puede_ver_modulo('usuarios')): ?>
+            <?php if (verModulo('usuarios')): ?>
                 <div class="col-12 col-md-4">
                     <div class="modulo-box">
                         <a href="usuarios.php">
@@ -100,7 +118,7 @@ function tienePuesto($puesto) {
                 </div>
             <?php endif; ?>
 
-            <?php if (puede_ver_modulo('kpis')): ?>
+            <?php if (verModulo('kpis')): ?>
                 <div class="col-12 col-md-4">
                     <div class="modulo-box">
                         <a href="kpis_mantenimiento.php">
@@ -111,12 +129,23 @@ function tienePuesto($puesto) {
                 </div>
             <?php endif; ?>
 
-            <?php if (puede_ver_modulo('configuracion')): ?>
+            <?php if (verModulo('configuracion')): ?>
                 <div class="col-12 col-md-4">
                     <div class="modulo-box">
                         <a href="panel_config.php">
                             <span class="modulo-icon">⚙️</span>
                             Configuración
+                        </a>
+                    </div>
+                </div>
+            <?php endif; ?>
+
+            <?php if (verModulo('camarista')): ?>
+                <div class="col-12 col-md-4">
+                    <div class="modulo-box">
+                        <a href="reporte_camarista.php">
+                            <span class="modulo-icon">🧹</span>
+                            Reporte Camarista
                         </a>
                     </div>
                 </div>

--- a/minipanel_mantenimiento.php
+++ b/minipanel_mantenimiento.php
@@ -7,6 +7,25 @@ include 'auth.php'; // Proteccin de sesin
 include 'conexion.php'; // Ahora usa el archivo de conexin
 header('Content-Type: text/html; charset=utf-8');
 
+// --- Control de acceso dinámico por rol/puesto ---
+session_start();
+
+$rol = $_SESSION['rol'] ?? ($_SESSION['user_role'] ?? '');
+$puesto = $_SESSION['puesto'] ?? '';
+
+$acceso_total = ['Administrador', 'Gerente', 'Superadmin', 'CEO', 'Webmaster'];
+
+$tiene_acceso_mantenimiento = (
+    in_array($rol, $acceso_total) ||
+    $rol === 'Servicio al Cliente' ||
+    in_array($rol, ['Camarista', 'Ama de Llaves'])
+);
+
+if (!$tiene_acceso_mantenimiento) {
+    header('Location: acceso_denegado.php');
+    exit;
+}
+
 
 // 98 KPIs
 $ordenes_totales = $conn->query("SELECT COUNT(*) AS total FROM ordenes_mantenimiento")->fetch_assoc()['total'];

--- a/ordenes_mantenimiento.php
+++ b/ordenes_mantenimiento.php
@@ -9,6 +9,25 @@ error_reporting(E_ALL);
 
 include 'conexion.php';
 
+// --- Control de acceso dinámico por rol/puesto ---
+session_start();
+
+$rol = $_SESSION['rol'] ?? ($_SESSION['user_role'] ?? '');
+$puesto = $_SESSION['puesto'] ?? '';
+
+$acceso_total = ['Administrador', 'Gerente', 'Superadmin', 'CEO', 'Webmaster'];
+
+$tiene_acceso_mantenimiento = (
+    in_array($rol, $acceso_total) ||
+    $rol === 'Servicio al Cliente' ||
+    in_array($rol, ['Camarista', 'Ama de Llaves'])
+);
+
+if (!$tiene_acceso_mantenimiento) {
+    header('Location: acceso_denegado.php');
+    exit;
+}
+
 if (isset($_GET['modal'])) {
 ?>
 <form action="procesar_mantenimiento.php" method="POST" enctype="multipart/form-data">

--- a/procesar_mantenimiento.php
+++ b/procesar_mantenimiento.php
@@ -1,6 +1,25 @@
 <?php
 include 'conexion.php'; // Conexión centralizada
 
+// --- Control de acceso dinámico por rol/puesto ---
+session_start();
+
+$rol = $_SESSION['rol'] ?? ($_SESSION['user_role'] ?? '');
+$puesto = $_SESSION['puesto'] ?? '';
+
+$acceso_total = ['Administrador', 'Gerente', 'Superadmin', 'CEO', 'Webmaster'];
+
+$tiene_acceso_mantenimiento = (
+    in_array($rol, $acceso_total) ||
+    $rol === 'Servicio al Cliente' ||
+    in_array($rol, ['Camarista', 'Ama de Llaves'])
+);
+
+if (!$tiene_acceso_mantenimiento) {
+    header('Location: acceso_denegado.php');
+    exit;
+}
+
 // Validar datos del formulario
 $alojamiento_id = $_POST['alojamiento_id'] ?? '';
 $descripcion = $_POST['descripcion_reporte'] ?? '';

--- a/reporte_camarista.php
+++ b/reporte_camarista.php
@@ -3,8 +3,9 @@ include 'auth.php';
 session_start();
 
 $puesto = strtolower(trim($_SESSION['puesto'] ?? ''));
+$rol = $_SESSION['rol'] ?? ($_SESSION['user_role'] ?? '');
 
-if ($puesto !== 'camarista') {
+if (!in_array($rol, ['Camarista', 'Ama de Llaves'])) {
     header('Location: minipanel_mantenimiento.php');
     exit;
 }


### PR DESCRIPTION
## Summary
- add per-role checks for maintenance modules
- update login to store `$_SESSION['rol']`
- generate `acceso_denegado.php` page
- restrict access for camaristas in `reporte_camarista.php`
- show/hide menu items based on role

## Testing
- `php -l ordenes_mantenimiento.php procesar_mantenimiento.php minipanel_mantenimiento.php menu_principal.php acceso_denegado.php login.php reporte_camarista.php`

------
https://chatgpt.com/codex/tasks/task_e_6848578206a883329f8daddeb4be7053