### PR TITLE
Fix PHP menu and page structure

### DIFF
--- a/menu_principal.php
+++ b/menu_principal.php
@@ -4,16 +4,17 @@ if (session_status() === PHP_SESSION_NONE) {
 }
 include 'auth.php';
 include 'router_roles.php';
-include 'verificar_acceso.php'; // << Reemplaza config y funciones auxiliares
+include 'verificar_acceso.php';
 
-// Redirección automática según el puesto (si aplica)
 redireccionar_por_puesto(obtener_puesto());
+
 $rol = isset($_SESSION['rol']) ? trim(ucwords(strtolower($_SESSION['rol']))) : '';
+
 function verModulo($modulo) {
     global $rol;
-    $rol = trim(ucwords(strtolower($rol)));
     $ver_todo = ['Administrador', 'Gerente', 'Superadmin', 'CEO', 'Webmaster'];
     $ver_mantenimiento = ['Servicio al Cliente', 'Camarista', 'Ama de Llaves'];
+
     switch ($modulo) {
         case 'mantenimiento':
             return in_array($rol, array_merge($ver_todo, $ver_mantenimiento));
@@ -29,6 +30,7 @@ function verModulo($modulo) {
         default:
             return false;
     }
+}
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -48,18 +50,22 @@ function verModulo($modulo) {
         .modulo-box:hover {
             box-shadow: 0 0 10px rgba(0,0,0,0.1);
             background-color: #e9ecef;
+        }
         .modulo-box a {
             text-decoration: none;
             color: #000;
             font-size: 1.2rem;
+        }
         .modulo-icon {
             font-size: 2.5rem;
             margin-bottom: 10px;
             display: block;
+        }
         @media (max-width: 767px) {
             .modulo-box {
                 margin-bottom: 20px;
             }
+        }
     </style>
 </head>
 <body class="bg-light">
@@ -67,6 +73,7 @@ function verModulo($modulo) {
         <h2 class="mb-4 text-center">Bienvenido, <?php echo htmlspecialchars($_SESSION['user_name']); ?></h2>
         <h4 class="mb-4 text-center">Selecciona un módulo</h4>
         <div class="row justify-content-center g-4">
+
             <?php if (verModulo('ordenes_compra')): ?>
                 <div class="col-12 col-md-4">
                     <div class="modulo-box">
@@ -77,30 +84,73 @@ function verModulo($modulo) {
                     </div>
                 </div>
             <?php endif; ?>
+
             <?php if (verModulo('mantenimiento')): ?>
+                <div class="col-12 col-md-4">
+                    <div class="modulo-box">
                         <a href="minipanel_mantenimiento.php">
                             <span class="modulo-icon">🛠️</span>
                             Mantenimiento
+                        </a>
+                    </div>
+                </div>
+            <?php endif; ?>
+
             <?php if (verModulo('servicio_cliente')): ?>
+                <div class="col-12 col-md-4">
+                    <div class="modulo-box">
                         <a href="minipanel_servicio_cliente.php">
                             <span class="modulo-icon">📞</span>
                             Servicio al Cliente
+                        </a>
+                    </div>
+                </div>
+            <?php endif; ?>
+
             <?php if (verModulo('usuarios')): ?>
+                <div class="col-12 col-md-4">
+                    <div class="modulo-box">
                         <a href="usuarios.php">
                             <span class="modulo-icon">👤</span>
                             Gestión de Usuarios
+                        </a>
+                    </div>
+                </div>
+            <?php endif; ?>
+
             <?php if (verModulo('kpis')): ?>
+                <div class="col-12 col-md-4">
+                    <div class="modulo-box">
                         <a href="kpis_mantenimiento.php">
                             <span class="modulo-icon">📊</span>
                             KPIs
+                        </a>
+                    </div>
+                </div>
+            <?php endif; ?>
+
             <?php if (verModulo('configuracion')): ?>
+                <div class="col-12 col-md-4">
+                    <div class="modulo-box">
                         <a href="panel_config.php">
                             <span class="modulo-icon">⚙️</span>
                             Configuración
+                        </a>
+                    </div>
+                </div>
+            <?php endif; ?>
+
             <?php if (verModulo('camarista')): ?>
+                <div class="col-12 col-md-4">
+                    <div class="modulo-box">
                         <a href="reporte_camarista.php">
                             <span class="modulo-icon">🧹</span>
                             Reporte Camarista
+                        </a>
+                    </div>
+                </div>
+            <?php endif; ?>
+
         </div>
     </div>
 </body>

--- a/panel_config.php
+++ b/panel_config.php
@@ -14,6 +14,7 @@ $filtro = ($rol === 'superadmin' || $rol === 'admin') ? "1=1" : "usuario_solicit
 // Contar órdenes propias o del negocio
 $total_ordenes = $conn->query("SELECT COUNT(*) AS total FROM ordenes_compra WHERE $filtro")->fetch_assoc()['total'];
 $total_proveedores = $conn->query("SELECT COUNT(*) AS total FROM proveedores")->fetch_assoc()['total'];
+$total_usuarios = $conn->query("SELECT COUNT(*) AS total FROM usuarios")->fetch_assoc()['total'];
 ?>
 <!DOCTYPE html>
 <html lang="es">

--- a/proveedores.php
+++ b/proveedores.php
@@ -3,45 +3,47 @@ if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 include 'auth.php';
-include 'conexion.php'; // Ahora usamos conexion.php
+include 'conexion.php';
 
-        <div class="mb-3">
-            <label>No. Cuenta</label>
-            <input type="text" name="numero_cuenta" class="form-control">
-        </div>
-        <div class="mb-3">
-            <label>Banco</label>
-            <input type="text" name="banco" class="form-control">
-        </div>
-        <div class="mb-3">
-            <label>Direcci¨®n</label>
-            <textarea name="direccion" class="form-control"></textarea>
-        </div>
-        <div class="mb-3">
-            <label>RFC (Opcional)</label>
-            <input type="text" name="rfc" class="form-control">
-        </div>
-        <div class="mb-3">
-            <label>Descripci¨®n del Servicio</label>
-            <textarea name="descripcion_servicio" class="form-control"></textarea>
-        </div>
-        <button type="submit" class="btn btn-warning w-100">Guardar</button>
-    </form>
+if (isset($_GET['modal'])) {
+?>
+<form action="procesar_proveedor.php" method="POST">
+    <div class="mb-3">
+        <label>No. Cuenta</label>
+        <input type="text" name="numero_cuenta" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label>Banco</label>
+        <input type="text" name="banco" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label>Dirección</label>
+        <textarea name="direccion" class="form-control"></textarea>
+    </div>
+    <div class="mb-3">
+        <label>RFC (Opcional)</label>
+        <input type="text" name="rfc" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label>Descripción del Servicio</label>
+        <textarea name="descripcion_servicio" class="form-control"></textarea>
+    </div>
+    <button type="submit" class="btn btn-warning w-100">Guardar</button>
+</form>
 <?php
-    exit; // Evita que se cargue toda la p¨¢gina si se usa en un modal
+    exit;
 }
 
-// ”9Ý8 Si no es un modal, cargar la vista completa
+// Si no es un modal, cargar la vista completa
 include 'header.php';
 ?>
-
 <div class="container mt-5">
     <h2 class="mb-4">Lista de Proveedores</h2>
     <table class="table table-striped">
         <thead>
             <tr>
                 <th>Nombre</th>
-                <th>Tel¨¦fono</th>
+                <th>Teléfono</th>
                 <th>Email</th>
                 <th>Banco</th>
                 <th>Acciones</th>
@@ -59,12 +61,11 @@ include 'header.php';
                     <td><?php echo htmlspecialchars($proveedor['banco']); ?></td>
                     <td>
                         <a href="editar_proveedor.php?id=<?php echo $proveedor['id']; ?>" class="btn btn-sm btn-warning">Editar</a>
-                        <a href="eliminar_proveedor.php?id=<?php echo $proveedor['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('0†7Seguro que deseas eliminar este proveedor?')">Eliminar</a>
+                        <a href="eliminar_proveedor.php?id=<?php echo $proveedor['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('¿Seguro que deseas eliminar este proveedor?')">Eliminar</a>
                     </td>
                 </tr>
             <?php endwhile; ?>
         </tbody>
     </table>
 </div>
-
 <?php include 'footer.php'; ?>

--- a/usuarios.php
+++ b/usuarios.php
@@ -8,6 +8,8 @@ include 'conexion.php';
 // Solo superadmin o admin pueden entrar a este módulo
 if (!in_array($_SESSION['user_role'], ['superadmin', 'admin'])) {
     die("Acceso no autorizado.");
+}
+
 // 📌 Si la petición viene del modal (usuarios.php?modal=1), solo devuelve el formulario
 if (isset($_GET['modal'])) {
 ?>
@@ -18,30 +20,43 @@ if (isset($_GET['modal'])) {
         <input type="text" class="form-control" id="nombre" name="nombre" required>
     </div>
     <!-- Teléfono -->
+    <div class="mb-3">
         <label for="telefono" class="form-label">Teléfono</label>
         <input type="text" class="form-control" id="telefono" name="telefono" required>
+    </div>
     <!-- Email -->
+    <div class="mb-3">
         <label for="email" class="form-label">Correo Electrónico</label>
         <input type="email" class="form-control" id="email" name="email" required>
+    </div>
     <!-- Puesto -->
+    <div class="mb-3">
         <label for="puesto" class="form-label">Puesto</label>
         <input type="text" class="form-control" id="puesto" name="puesto" required>
+    </div>
     <!-- Contraseña -->
+    <div class="mb-3">
         <label for="password" class="form-label">Contraseña</label>
         <input type="password" class="form-control" id="password" name="password" required>
+    </div>
     <!-- Rol -->
+    <div class="mb-3">
         <label for="rol" class="form-label">Rol</label>
         <select class="form-control" id="rol" name="rol" required>
             <option value="user">Usuario</option>
             <option value="admin">Administrador</option>
             <option value="superadmin">Superadministrador</option>
         </select>
-    <!-- Botón -->
+    </div>
     <button type="submit" class="btn btn-primary w-100">Registrar Usuario</button>
 </form>
+<?php
     exit;
+}
+
 // Página completa
 include 'header.php';
+?>
 <div class="container mt-5">
     <h2 class="mb-4">Lista de Usuarios</h2>
     <table class="table table-striped">
@@ -64,6 +79,7 @@ include 'header.php';
                 if ($_SESSION['user_role'] === 'superadmin') {
                     $puede_editar = $puede_eliminar = true;
                 } elseif ($_SESSION['user_role'] === 'admin' && $usuario['rol'] !== 'superadmin') {
+                    $puede_editar = $puede_eliminar = true;
                 }
             ?>
                 <tr>
@@ -78,6 +94,7 @@ include 'header.php';
                         <?php endif; ?>
                         <?php if ($puede_eliminar): ?>
                             <a href="eliminar_usuario.php?id=<?php echo $usuario['id']; ?>" class="btn btn-sm btn-danger" onclick="return confirm('¿Seguro que deseas eliminar este usuario?')">Eliminar</a>
+                        <?php endif; ?>
                     </td>
                 </tr>
             <?php endwhile; ?>


### PR DESCRIPTION
## Summary
- replace `menu_principal.php` with correct markup
- fix broken control structures in `usuarios.php`
- add missing `$total_usuarios` calculation
- clean up `proveedores.php` structure

## Testing
- `php -l menu_principal.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486b923dd08332ac670c2e92b62b8b