### PR TITLE
Fix export warnings and add abono file upload

### DIFF
--- a/exportar_compras.php
+++ b/exportar_compras.php
@@ -9,16 +9,16 @@ include 'conexion.php';
 $output = fopen('php://output','w');
 
 $mapa_columnas = [
-    'folio' => 'oc.folio',
+    'folio' => 'oc.folio AS folio',
     'proveedor' => 'p.nombre AS proveedor',
-    'monto' => 'oc.monto',
-    'vencimiento' => 'oc.vencimiento_pago',
-    'concepto' => 'oc.concepto_pago',
-    'tipo' => 'oc.tipo_pago',
-    'factura' => 'oc.genera_factura',
+    'monto' => 'oc.monto AS monto',
+    'vencimiento' => 'oc.vencimiento_pago AS vencimiento',
+    'concepto' => 'oc.concepto_pago AS concepto',
+    'tipo' => 'oc.tipo_pago AS tipo',
+    'factura' => 'oc.genera_factura AS factura',
     'usuario' => 'u.nombre AS usuario',
     'unidad_negocio' => 'un.nombre AS unidad_negocio',
-    'estatus' => 'oc.estatus_pago'
+    'estatus' => 'oc.estatus_pago AS estatus'
 ];
 
 $mapa_titulos = [
@@ -87,7 +87,7 @@ $res = $conn->query($query);
 while($row = $res->fetch_assoc()){
     $fila=[];
     foreach($cols as $c){
-        $fila[]=$row[$c];
+        $fila[] = isset($row[$c]) ? $row[$c] : '';
     }
     fputcsv($output,$fila);
 }

--- a/guardar_abono.php
+++ b/guardar_abono.php
@@ -1,0 +1,45 @@
+<?php
+include 'conexion.php';
+
+$folio = $_POST['folio'] ?? '';
+$monto = $_POST['monto'] ?? '';
+$fecha = $_POST['fecha'] ?? '';
+$comentario = $_POST['comentario'] ?? '';
+
+if ($folio === '' || $monto === '' || $fecha === '') {
+    echo 'error: Faltan datos';
+    exit;
+}
+
+$comprobante_url = null;
+if (!empty($_FILES['comprobante']['name'])) {
+    $permitidos = ['jpg','jpeg','png','gif','pdf'];
+    $ext = strtolower(pathinfo($_FILES['comprobante']['name'], PATHINFO_EXTENSION));
+    if (!in_array($ext, $permitidos) || $_FILES['comprobante']['size'] > 5*1024*1024) {
+        echo 'error: Archivo no permitido o excede tamaño';
+        exit;
+    }
+
+    $nombre_archivo = uniqid('comprobante_') . '.' . $ext;
+    $ruta = 'uploads/comprobantes/' . $nombre_archivo;
+    if (!move_uploaded_file($_FILES['comprobante']['tmp_name'], $ruta)) {
+        echo 'error: No se pudo subir archivo';
+        exit;
+    }
+    $comprobante_url = $ruta;
+}
+
+$stmt = $conn->prepare("INSERT INTO abonos_ordenes_compra (folio, monto, fecha, comentario, comprobante_url) VALUES (?, ?, ?, ?, ?)");
+if(!$stmt){
+    echo 'error: ' . $conn->error;
+    exit;
+}
+$stmt->bind_param('sdsss', $folio, $monto, $fecha, $comentario, $comprobante_url);
+
+if ($stmt->execute()) {
+    echo 'ok';
+} else {
+    echo 'error: ' . $stmt->error;
+}
+exit;
+?>

--- a/minipanel.php
+++ b/minipanel.php
@@ -674,6 +674,10 @@
             <label for="comentario" class="form-label">Comentario</label>
             <textarea class="form-control" name="comentario" rows="3"></textarea>
           </div>
+          <div class="mb-3">
+            <label for="comprobante" class="form-label">Comprobante</label>
+            <input type="file" class="form-control" name="comprobante" accept="image/*,application/pdf">
+          </div>
         </div>
         <div class="modal-footer">
           <button type="submit" class="btn btn-success">Guardar Abono</button>


### PR DESCRIPTION
## Summary
- prevent undefined indexes in CSV export and ensure proper column aliases
- support uploading comprobante files when saving abonos
- add file input in abono modal for uploading comprobantes

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c391afb808332a12a92ddd8721e14