### PR TITLE
Unify gastos with order support

### DIFF
--- a/create_gastos_table.php
+++ b/create_gastos_table.php
@@ -19,7 +19,7 @@ $sql = "CREATE TABLE IF NOT EXISTS gastos (
   estatus ENUM('Pagado','Pago parcial','Vencido','Por pagar') DEFAULT 'Pagado',
   concepto TEXT,
   orden_folio VARCHAR(50),
-  origen ENUM('Directo','OrdenCompra') DEFAULT 'Directo',
+  origen ENUM('Directo','Orden') DEFAULT 'Directo',
   origen_id VARCHAR(50),
   fecha_creacion TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (proveedor_id) REFERENCES proveedores(id),

--- a/guardar_gasto.php
+++ b/guardar_gasto.php
@@ -11,6 +11,7 @@ $medio_pago = $_POST['medio_pago'] ?? 'Transferencia';
 $cuenta = $_POST['cuenta_bancaria'] ?? null;
 $concepto = $_POST['concepto'] ?? null;
 $origen = $_POST['origen'] ?? 'Directo';
+$orden_folio = $_POST['orden_folio'] ?? null;
 $origen_id = $_POST['origen_id'] ?? null;
 
 if (!$proveedor_id || !$monto || !$fecha_pago || !$unidad_id) {
@@ -23,8 +24,13 @@ $prefix = "G-$anio-";
 $count = $conn->query("SELECT COUNT(*) AS total FROM gastos WHERE folio LIKE '$prefix%'")->fetch_assoc()['total'] + 1;
 $folio = $prefix . str_pad($count, 4, '0', STR_PAD_LEFT);
 
-$stmt = $conn->prepare("INSERT INTO gastos (folio, proveedor_id, monto, fecha_pago, unidad_negocio_id, tipo_gasto, medio_pago, cuenta_bancaria, concepto, origen, origen_id) VALUES (?,?,?,?,?,?,?,?,?,?,?)");
-$stmt->bind_param('sidssssssss', $folio, $proveedor_id, $monto, $fecha_pago, $unidad_id, $tipo_gasto, $medio_pago, $cuenta, $concepto, $origen, $origen_id);
+$estatus = 'Pagado';
+if ($origen === 'Orden') {
+    $estatus = (strtotime($fecha_pago) < strtotime(date('Y-m-d'))) ? 'Vencido' : 'Por pagar';
+}
+
+$stmt = $conn->prepare("INSERT INTO gastos (folio, proveedor_id, monto, fecha_pago, unidad_negocio_id, tipo_gasto, medio_pago, cuenta_bancaria, estatus, concepto, orden_folio, origen, origen_id) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)");
+$stmt->bind_param('sidsissssssss', $folio, $proveedor_id, $monto, $fecha_pago, $unidad_id, $tipo_gasto, $medio_pago, $cuenta, $estatus, $concepto, $orden_folio, $origen, $origen_id);
 if ($stmt->execute()) {
     echo 'ok';
 } else {

--- a/modal_gasto.php
+++ b/modal_gasto.php
@@ -7,6 +7,24 @@ if (!isset($_GET['modal'])) {
 ?>
 <form id="formGasto" method="POST" action="guardar_gasto.php">
     <div class="mb-3">
+        <label class="form-label">Tipo de registro</label>
+        <select id="tipoRegistro" class="form-select">
+            <option value="Directo">Gasto Directo</option>
+            <option value="Orden">Orden de Compra</option>
+        </select>
+    </div>
+    <div class="mb-3 d-none" id="campoOrden">
+        <label class="form-label">Orden relacionada</label>
+        <select name="orden_folio" class="form-select">
+            <option value="">Seleccione orden</option>
+            <?php
+            $ord=$conn->query("SELECT oc.folio, p.nombre AS prov FROM ordenes_compra oc JOIN proveedores p ON oc.proveedor_id=p.id WHERE oc.estatus_pago IN ('Por pagar','Vencido','Pago parcial') ORDER BY oc.folio DESC");
+            while($row=$ord->fetch_assoc()): ?>
+            <option value="<?php echo $row['folio']; ?>"><?php echo htmlspecialchars($row['folio'].' - '.$row['prov']); ?></option>
+            <?php endwhile; ?>
+        </select>
+    </div>
+    <div class="mb-3">
         <label class="form-label">Proveedor</label>
         <select name="proveedor_id" class="form-select" required>
             <option value="">Seleccione proveedor</option>
@@ -57,7 +75,6 @@ if (!isset($_GET['modal'])) {
         <label class="form-label">Concepto</label>
         <textarea name="concepto" class="form-control"></textarea>
     </div>
-    <input type="hidden" name="origen" value="Directo">
     <input type="hidden" name="origen_id" value="">
     <div class="text-end">
         <button type="submit" class="btn btn-success">Guardar</button>
@@ -79,5 +96,24 @@ document.getElementById('formGasto').addEventListener('submit', function(e) {
             }
         });
 });
+
+// Cambiar tipo de registro
+const tipoReg=document.getElementById('tipoRegistro');
+const campoOrden=document.getElementById('campoOrden');
+const inputOrigen=document.createElement('input');
+inputOrigen.type='hidden';
+inputOrigen.name='origen';
+document.getElementById('formGasto').appendChild(inputOrigen);
+tipoReg.addEventListener('change',actualizar);
+function actualizar(){
+    if(tipoReg.value==='Orden'){
+        campoOrden.classList.remove('d-none');
+        inputOrigen.value='Orden';
+    }else{
+        campoOrden.classList.add('d-none');
+        inputOrigen.value='Directo';
+    }
+}
+actualizar();
 </script>
 <?php exit; ?>


### PR DESCRIPTION
## Summary
- adjust gastos table creator to use `Orden`
- extend gasto registration form with order support
- set gasto status based on origin and order link

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864540ccce883329ed76828eb7a336c