### PR TITLE
Enhance gastos view with advanced filtering and quick actions

### DIFF
--- a/exportar_gastos.php
+++ b/exportar_gastos.php
@@ -20,6 +20,14 @@ if (!empty($_GET['fecha_fin'])) {
     $f = $conn->real_escape_string($_GET['fecha_fin']);
     $cond[] = "g.fecha_pago <= '$f'";
 }
+if (!empty($_GET['estatus'])) {
+    $e = $conn->real_escape_string($_GET['estatus']);
+    $cond[] = "g.estatus='$e'";
+}
+if (!empty($_GET['origen'])) {
+    $o = $conn->real_escape_string($_GET['origen']);
+    $cond[] = "g.origen='$o'";
+}
 $where = $cond ? 'WHERE '.implode(' AND ',$cond) : '';
 
 $sql = "SELECT g.folio, p.nombre AS proveedor, g.monto, g.fecha_pago, un.nombre AS unidad, g.tipo_gasto, g.medio_pago, g.cuenta_bancaria, g.concepto, g.estatus FROM gastos g LEFT JOIN proveedores p ON g.proveedor_id=p.id LEFT JOIN unidades_negocio un ON g.unidad_negocio_id=un.id $where ORDER BY g.fecha_pago DESC";

--- a/exportar_gastos_pdf.php
+++ b/exportar_gastos_pdf.php
@@ -20,6 +20,14 @@ if (!empty($_GET['fecha_fin'])) {
     $f = $conn->real_escape_string($_GET['fecha_fin']);
     $cond[] = "g.fecha_pago <= '$f'";
 }
+if (!empty($_GET['estatus'])) {
+    $e = $conn->real_escape_string($_GET['estatus']);
+    $cond[] = "g.estatus='$e'";
+}
+if (!empty($_GET['origen'])) {
+    $o = $conn->real_escape_string($_GET['origen']);
+    $cond[] = "g.origen='$o'";
+}
 $where = $cond ? 'WHERE '.implode(' AND ',$cond) : '';
 
 $sql = "SELECT g.folio, p.nombre AS proveedor, g.monto, g.fecha_pago, un.nombre AS unidad, g.tipo_gasto, g.medio_pago, g.cuenta_bancaria, g.concepto, g.estatus FROM gastos g LEFT JOIN proveedores p ON g.proveedor_id=p.id LEFT JOIN unidades_negocio un ON g.unidad_negocio_id=un.id $where ORDER BY g.fecha_pago DESC";


### PR DESCRIPTION
## Summary
- extend gastos queries with `estatus` and `origen`
- expose new filter fields on gastos listing
- add quick filter buttons for common views
- allow export scripts to respect all filters

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a0f58d10833285073f44badeea1b