### PR TITLE
Improve DB reuse and password handling

### DIFF
--- a/create_gastos_table.php
+++ b/create_gastos_table.php
@@ -1,11 +1,5 @@
 <?php
-$servername = "localhost";
-$username   = "corazon_caribe";
-$password   = "Kantun.01*";
-$database   = "corazon_orderdecompras";
-
-$conn = new mysqli($servername, $username, $password, $database);
-
+include 'conexion.php';
 $sql = "CREATE TABLE IF NOT EXISTS gastos (
   id INT AUTO_INCREMENT PRIMARY KEY,
   folio VARCHAR(20) UNIQUE,

--- a/create_lavanderia_table.php
+++ b/create_lavanderia_table.php
@@ -1,11 +1,5 @@
 <?php
-$servername = "localhost";
-$username   = "corazon_caribe";
-$password   = "Kantun.01*";
-$database   = "corazon_orderdecompras";
-
-$conn = new mysqli($servername, $username, $password, $database);
-
+include 'conexion.php';
 $sql = "CREATE TABLE IF NOT EXISTS ordenes_lavanderia (
   id INT AUTO_INCREMENT PRIMARY KEY,
   folio VARCHAR(20) UNIQUE,

--- a/create_tables.php
+++ b/create_tables.php
@@ -1,11 +1,6 @@
 <?php
 // database/migrations/create_proveedores_table.php
-$servername = "localhost";
-$username = "corazon_caribe";
-$password = "Kantun.01*";
-$database = "corazon_orderdecompras";
-
-$conn = new mysqli($servername, $username, $password, $database);
+include 'conexion.php';
 
 // Proveedores Table
 $conn->query("

--- a/create_transfers_table.php
+++ b/create_transfers_table.php
@@ -1,11 +1,5 @@
 <?php
-$servername = "localhost";
-$username   = "corazon_caribe";
-$password   = "Kantun.01*";
-$database   = "corazon_orderdecompras";
-
-$conn = new mysqli($servername, $username, $password, $database);
-
+include 'conexion.php';
 $sql = "CREATE TABLE IF NOT EXISTS ordenes_transfers (
   id INT AUTO_INCREMENT PRIMARY KEY,
   folio VARCHAR(20) UNIQUE,

--- a/listar_usuarios.php
+++ b/listar_usuarios.php
@@ -9,11 +9,6 @@ if (!isset($_SESSION['user_id']) || $_SESSION['user_role'] !== 'superadmin') {
     die("Acceso no autorizado.");
 }
 
-$conn = new mysqli($servername, $username, $password, $database);
-
-if ($conn->connect_error) {
-    die("Conexión fallida: " . $conn->connect_error);
-}
 
 // Obtener usuarios
 $result = $conn->query("SELECT id, nombre, email, telefono, puesto, rol FROM usuarios");

--- a/login.php
+++ b/login.php
@@ -1,18 +1,7 @@
 <?php
 session_start();
+include 'conexion.php';
 
-$servername = "localhost";
-$username = "corazon_caribe";
-$password = "Kantun.01*";
-$database = "corazon_orderdecompras";
-
-// Crear conexi贸n
-$conn = new mysqli($servername, $username, $password, $database);
-
-// Revisar conexi贸n
-if ($conn->connect_error) {
-    die("Conexi贸n fallida: " . $conn->connect_error);
-}
 
 // Obtener datos del formulario
 $email = $_POST['email'] ?? '';
@@ -27,18 +16,15 @@ $result = $stmt->get_result();
 
 if ($result->num_rows === 1) {
     $user = $result->fetch_assoc();
-    // Verificar contrase帽a
+    // Verificar contrase脙卤a
 
-if ($password === $user['password']) {
+if (password_verify($password, $user['password'])) {
 
         $_SESSION['user_id'] = $user['id'];
         $_SESSION['user_name'] = $user['nombre'];
         $_SESSION['user_role'] = $user['rol']; // Almacena el rol del usuario
-        $_SESSION['puesto'] = $user['puesto']; // ⚠️ este es el que falta
+        $_SESSION['puesto'] = $user['puesto']; // 聛7虏2聞1聜5 este es el que falta
         header("Location: menu_principal.php");
-        echo "<pre>";
-print_r($_SESSION);
-exit;
         exit;
     } else {
         header("Location: index.php?error=Credenciales incorrectas");
@@ -48,8 +34,3 @@ exit;
     header("Location: index.php?error=Usuario no encontrado");
     exit;
 }
-
-echo "<pre>";
-print_r($_SESSION);
-exit;
-

--- a/minipanel1.php
+++ b/minipanel1.php
@@ -1,17 +1,8 @@
 <?php
 session_start();
 include 'auth.php'; // Protección de sesión
+include 'conexion.php';
 
-$servername = "localhost";
-$username = "corazon_caribe";
-$password = "Kantun.01*";
-$database = "corazon_orderdecompras";
-
-$conn = new mysqli($servername, $username, $password, $database);
-
-if ($conn->connect_error) {
-    die("Conexión fallida: " . $conn->connect_error);
-}
 
 // KPIs
 $ordenes_totales = $conn->query("SELECT COUNT(*) AS total FROM ordenes_compra")->fetch_assoc()['total'];

--- a/procesar_usuario.php
+++ b/procesar_usuario.php
@@ -13,6 +13,7 @@ $telefono = $_POST['telefono'] ?? '';
 $email    = $_POST['email'] ?? '';
 $puesto   = $_POST['puesto'] ?? '';
 $password = $_POST['password'] ?? '';
+$hashedPassword = password_hash($password, PASSWORD_DEFAULT);
 $rol      = $_POST['rol'] ?? 'user';
 
 // Validar campos
@@ -20,10 +21,10 @@ if (empty($nombre) || empty($telefono) || empty($email) || empty($puesto) || emp
     die("Error: Todos los campos son obligatorios.");
 }
 
-// Guardar contraseña como texto plano (simple)
+// Guardar el hash de la contraseña
 $sql = "INSERT INTO usuarios (nombre, telefono, email, puesto, password, rol) VALUES (?, ?, ?, ?, ?, ?)";
 $stmt = $conn->prepare($sql);
-$stmt->bind_param("ssssss", $nombre, $telefono, $email, $puesto, $password, $rol);
+$stmt->bind_param("ssssss", $nombre, $telefono, $email, $puesto, $hashedPassword, $rol);
 
 if ($stmt->execute()) {
     echo "Usuario registrado correctamente. <a href='usuarios.php'>Regresar</a>";


### PR DESCRIPTION
## Summary
- centralize DB connections by including `conexion.php`
- hash passwords on user creation
- verify hashed password at login
- remove debugging statements

## Testing
- `php -l login.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f13877588332b50f6d6e33698691