### PR TITLE
Restore purchase order page and split service list

### DIFF
--- a/minipanel_servicio_cliente.php
+++ b/minipanel_servicio_cliente.php
@@ -223,6 +223,9 @@ function corregirCodificacion($cadena) {
     <div class="col-12 col-md-auto">
         <a href="kpis_servicio_cliente.php" class="btn btn-primary btn-custom w-100">Ver Detalles de KPIs</a>
         </div>
+    <div class="col-12 col-md-auto">
+        <a href="ordenes_servicio_cliente_list.php" class="btn btn-outline-secondary btn-custom w-100">Ver Tabla Simplificada</a>
+    </div>
 </div>
 
         <h4 class="mb-3">Reportes de Servicio al Cliente</h4>

--- a/ordenes_servicio_cliente_list.php
+++ b/ordenes_servicio_cliente_list.php
@@ -1,0 +1,48 @@
+<?php
+session_start();
+include 'auth.php';
+include 'conexion.php';
+include 'header.php';
+?>
+
+<div class="container mt-5">
+    <h2 class="mb-4">Lista de Órdenes de Servicio al Cliente</h2>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>Folio</th>
+                <th>Alojamiento</th>
+                <th>Descripción</th>
+                <th>Fecha</th>
+                <th>Vencimiento</th>
+                <th>Usuario</th>
+                <th>Unidad de Negocio</th>
+                <th>Estatus</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php
+            $ordenes = $conn->query("SELECT folio, descripcion_reporte, fecha_reporte, fecha_vencimiento, estatus,
+                                     (SELECT nombre FROM alojamientos WHERE id = alojamiento_id) AS alojamiento,
+                                     (SELECT nombre FROM usuarios WHERE id = usuario_solicitante_id) AS usuario,
+                                     (SELECT nombre FROM unidades_negocio WHERE id = unidad_negocio_id) AS unidad_negocio
+                               FROM ordenes_servicio_cliente");
+            while ($orden = $ordenes->fetch_assoc()):
+            ?>
+                <tr>
+                    <td><?php echo htmlspecialchars($orden['folio']); ?></td>
+                    <td><?php echo htmlspecialchars($orden['alojamiento']); ?></td>
+                    <td><?php echo htmlspecialchars($orden['descripcion_reporte']); ?></td>
+                    <td><?php echo htmlspecialchars($orden['fecha_reporte']); ?></td>
+                    <td><?php echo htmlspecialchars($orden['fecha_vencimiento']); ?></td>
+                    <td><?php echo htmlspecialchars($orden['usuario']); ?></td>
+                    <td><?php echo htmlspecialchars($orden['unidad_negocio']); ?></td>
+                    <td><?php echo htmlspecialchars($orden['estatus']); ?></td>
+                </tr>
+            <?php endwhile; ?>
+        </tbody>
+    </table>
+</div>
+
+<?php include 'footer.php'; ?>
+


### PR DESCRIPTION
## Summary
- create `ordenes_servicio_cliente_list.php` with a table of service orders
- link to the new list from `minipanel_servicio_cliente.php`

## Testing
- `php -l ordenes_servicio_cliente_list.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868130219b483328b6565086695da99