### PR TITLE
Implement image validation

### DIFF
--- a/guardar_abono.php
+++ b/guardar_abono.php
@@ -15,14 +15,35 @@ $comprobante_url = null;
 if (!empty($_FILES['comprobante']['name'])) {
     $permitidos = ['jpg','jpeg','png','gif','pdf'];
     $ext = strtolower(pathinfo($_FILES['comprobante']['name'], PATHINFO_EXTENSION));
-    if (!in_array($ext, $permitidos) || $_FILES['comprobante']['size'] > 5*1024*1024) {
-        echo 'error: Archivo no permitido o excede tamaño';
+    $tmpName = $_FILES['comprobante']['tmp_name'];
+    if (!in_array($ext, $permitidos)) {
+        echo 'error: Archivo no permitido';
+        exit;
+    }
+
+    if (in_array($ext, ['jpg','jpeg','png','gif'])) {
+        $allowedTypes = ['image/jpeg','image/png','image/gif'];
+        $maxSize = 5 * 1024 * 1024; // 5MB
+        $mimeType = mime_content_type($tmpName);
+        $size = $_FILES['comprobante']['size'];
+
+        if (!in_array($mimeType, $allowedTypes)) {
+            echo 'error: Formato de imagen no permitido';
+            exit;
+        }
+
+        if ($size > $maxSize) {
+            echo 'error: Imagen excede el tamaño máximo de 5MB';
+            exit;
+        }
+    } else if ($_FILES['comprobante']['size'] > 5*1024*1024) {
+        echo 'error: Archivo excede tamaño máximo';
         exit;
     }
 
     $nombre_archivo = uniqid('comprobante_') . '.' . $ext;
     $ruta = 'uploads/comprobantes/' . $nombre_archivo;
-    if (!move_uploaded_file($_FILES['comprobante']['tmp_name'], $ruta)) {
+    if (!move_uploaded_file($tmpName, $ruta)) {
         echo 'error: No se pudo subir archivo';
         exit;
     }

--- a/guardar_nota.php
+++ b/guardar_nota.php
@@ -28,6 +28,24 @@ if (!empty($_FILES['archivo']['name']) && $_FILES['archivo']['error'] === UPLOAD
         exit;
     }
 
+    if (in_array($ext, ['jpg', 'jpeg', 'png'])) {
+        $allowedTypes = ['image/jpeg', 'image/png'];
+        $maxSize = 5 * 1024 * 1024; // 5MB
+        $tmpName = $_FILES['archivo']['tmp_name'];
+        $mimeType = mime_content_type($tmpName);
+        $size = $_FILES['archivo']['size'];
+
+        if (!in_array($mimeType, $allowedTypes)) {
+            echo "Formato de imagen no permitido. Solo JPEG y PNG.";
+            exit;
+        }
+
+        if ($size > $maxSize) {
+            echo "La imagen excede el tamaño máximo de 5MB.";
+            exit;
+        }
+    }
+
     $nombre_limpio = preg_replace("/[^a-zA-Z0-9._-]/", "", basename($_FILES['archivo']['name']));
     $archivo_nombre = "uploads/nota_{$folio}_{$nombre_limpio}";
 

--- a/procesar_orden.php
+++ b/procesar_orden.php
@@ -29,10 +29,26 @@ $folio = "OC-$fecha-$conteo"; // Ejemplo: OC-20250205-3
 // Procesar archivo si aplica
 $comprobante_path = null;
 if (!empty($_FILES['comprobante']['name'])) {
+    $allowedTypes = ['image/jpeg', 'image/png'];
+    $maxSize = 5 * 1024 * 1024; // 5MB
+    $tmpName = $_FILES['comprobante']['tmp_name'];
+    $mimeType = mime_content_type($tmpName);
+    $size = $_FILES['comprobante']['size'];
+
+    if (!in_array($mimeType, $allowedTypes)) {
+        die("Formato de comprobante no permitido. Solo JPEG y PNG.");
+    }
+
+    if ($size > $maxSize) {
+        die("El comprobante excede el tamaño máximo de 5MB.");
+    }
+
     $directorio = "uploads/";
     $nombre_archivo = time() . "_" . basename($_FILES['comprobante']['name']);
     $comprobante_path = $directorio . $nombre_archivo;
-    move_uploaded_file($_FILES['comprobante']['tmp_name'], $comprobante_path);
+    if (!move_uploaded_file($tmpName, $comprobante_path)) {
+        die("Error al subir el comprobante.");
+    }
 }
 
 // Validaciones


### PR DESCRIPTION
## Summary
- validate uploaded `comprobante` images in purchase orders
- add mime/type checks for notes credit file upload
- enforce mime and size checks when saving payment vouchers

## Testing
- `php -l procesar_orden.php`
- `php -l guardar_nota.php`
- `php -l guardar_abono.php`


------
https://chatgpt.com/codex/tasks/task_e_686815d5d6408332825af92101a6cb40