### PR TITLE
Cambio de etiquetas a Tareas

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project is a PHP based management system for purchase orders, maintenance r
 - `minipanel.php` and purchases related files: handle purchase orders.
 - `usuarios.php` & `editar_usuario.php`: user management.
 - `kpis_mantenimiento.php` and similar: KPI dashboards.
-- Newly added `minipanel_servicio_cliente.php` module replicates the maintenance workflow for **Servicio al Cliente**.
+- Newly added `minipanel_servicio_cliente.php` module replicates the maintenance workflow for **Tareas**.
 - `minipanel_transfers.php` module allows registering airport-hotel transfers.
 
 ## Database
@@ -20,7 +20,7 @@ The application expects a MySQL database configured in `conexion.php`. Tables su
 
 ## Modules
 - **Mantenimiento**: existing module for maintenance requests.
-- **Servicio al Cliente**: duplicated from maintenance, adjusted for customer service requests. Only roles *servicio al cliente*, *gerente* and *admin* can use it.
+- **Tareas**: duplicated from maintenance, adjusted for customer service requests. Only roles *servicio al cliente*, *gerente* and *admin* can use it.
 - **Transfers**: module to manage private transfers between airport and hotels with filters, exports and KPIs.
 
 ## Puestos Múltiples

--- a/completar_servicio_cliente.php
+++ b/completar_servicio_cliente.php
@@ -30,7 +30,7 @@ if (!$orden) {
     </div>
 
     <div class="mb-3">
-        <label for="detalle_completado" class="form-label">Detalle del Trabajo Realizado</label>
+        <label for="detalle_completado" class="form-label">Detalle de la Tarea</label>
         <textarea class="form-control" name="detalle_completado" rows="3" required><?php echo htmlspecialchars($orden['detalle_completado'] ?? ''); ?></textarea>
     </div>
 

--- a/exportar_kpis_servicio_cliente_pdf.php
+++ b/exportar_kpis_servicio_cliente_pdf.php
@@ -43,7 +43,7 @@ $mes_terminados = obtener("SELECT COUNT(*) AS total FROM ordenes_servicio_client
 $cumplimiento_mes = ($mes_total > 0) ? round(($mes_terminados / $mes_total) * 100, 1) : 0;
 
 $html = "
-<h2 style='text-align:center;'>📊 KPIs de Servicio al Cliente</h2>
+<h2 style='text-align:center;'>📊 KPIs de Tareas</h2>
 <table border='1' cellpadding='8' cellspacing='0' style='width:100%; font-family:sans-serif; font-size:14px;'>
 <tr><th>Indicador</th><th>Valor</th></tr>
 <tr><td>Solicitudes Totales</td><td>$total</td></tr>

--- a/exportar_servicio_cliente_pdf.php
+++ b/exportar_servicio_cliente_pdf.php
@@ -51,7 +51,7 @@ $resultado = $conn->query($query);
 
 // Generar HTML
 $html = '<html><head><meta charset="UTF-8"></head><body>';
-$html .= '<h2 style="text-align:center;">Reporte de Servicio al Cliente</h2>';
+$html .= '<h2 style="text-align:center;">Reporte de Tareas</h2>';
 $html .= '<table border="1" cellspacing="0" cellpadding="4" style="width:100%; font-size:10px;">';
 $html .= '<thead>
 <tr>

--- a/generar_pdf_servicio_cliente.php
+++ b/generar_pdf_servicio_cliente.php
@@ -83,7 +83,7 @@ $html = '
     .img-thumb { max-width: 200px; max-height: 150px; display: block; margin-top: 10px; }
 </style>
 
-<h2 class="titulo">REPORTE DE SERVICIO AL CLIENTE</h2>
+<h2 class="titulo">Resumen de Tarea</h2>
 
 <div class="seccion">
   <h4>Información del Reporte</h4>

--- a/kpis_servicio_cliente.php
+++ b/kpis_servicio_cliente.php
@@ -6,7 +6,7 @@ include 'conexion.php';
 <html lang="es">
 <head>
   <meta charset="UTF-8">
-  <title>KPIs de Servicio al Cliente</title>
+  <title>KPIs de Tareas</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css" rel="stylesheet">
@@ -25,7 +25,7 @@ include 'conexion.php';
 </head>
 <body class="bg-light">
 <div class="container py-5">
-  <h2 class="mb-4">📊 KPIs de Servicio al Cliente</h2>
+  <h2 class="mb-4">📊 KPIs de Tareas</h2>
 
   <!-- 🎛️ Filtros -->
   <form id="formFiltros" class="row g-3 mb-4">

--- a/kpis_servicio_cliente_printable.php
+++ b/kpis_servicio_cliente_printable.php
@@ -31,7 +31,7 @@ $kpis = include 'kpis_servicio_cliente_data_core.php';
 </head>
 <body>
 <div class="container py-4">
-  <h2 class="mb-4 text-center">📊 KPIs de Servicio al Cliente (Vista para impresión)</h2>
+  <h2 class="mb-4 text-center">📊 KPIs de Tareas (Vista para impresión)</h2>
 
   <!-- KPIs -->
   <div class="section-title">🛠️ Indicadores Operativos</div>

--- a/menu_principal.php
+++ b/menu_principal.php
@@ -131,7 +131,7 @@ foreach ($modulos_disponibles as $m) {
                     <div class="modulo-box">
                         <a href="minipanel_servicio_cliente.php">
                             <span class="modulo-icon">📞</span>
-                            Servicio al Cliente
+                            Tareas
                         </a>
                     </div>
                 </div>

--- a/minipanel_servicio_cliente.php
+++ b/minipanel_servicio_cliente.php
@@ -106,7 +106,7 @@ function corregirCodificacion($cadena) {
     <meta charset="UTF-8">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Minipanel - Control de Gastos</title>
+    <title>Minipanel - Tareas</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <style>
         .container {
@@ -217,17 +217,17 @@ function corregirCodificacion($cadena) {
         </div>
     <?php endif; ?>
         <div class="col-12 col-md-auto">
-            <button class="btn btn-success btn-custom w-100" data-bs-toggle="modal" data-bs-target="#modalIngresarOrden">Ingresar Reporte de Servicio al Cliente</button>
+            <button class="btn btn-success btn-custom w-100" data-bs-toggle="modal" data-bs-target="#modalIngresarOrden">Ingresar Nueva Tarea</button>
         </div>
     <div class="col-12 col-md-auto">
         <button class="btn btn-info btn-custom w-100" data-bs-toggle="modal" data-bs-target="#modalKPIs">Resumen de KPIs</button>
     </div>
     <div class="col-12 col-md-auto">
-        <a href="kpis_servicio_cliente.php" class="btn btn-primary btn-custom w-100">Ver Detalles de KPIs</a>
+        <a href="kpis_servicio_cliente.php" class="btn btn-primary btn-custom w-100">Ver KPIs de Tareas</a>
         </div>
 </div>
 
-        <h4 class="mb-3">Reportes de Servicio al Cliente</h4>
+        <h4 class="mb-3">Listado de Tareas</h4>
     
 
 <!-- Filtros en Acorden -->
@@ -642,12 +642,12 @@ foreach ($columnas_ordenables as $col => $label):
     </div>
 </div>
 
-<!-- 98 MODAL: Ingresar Reporte de Servicio al Cliente -->
+<!-- 98 MODAL: Registrar Tarea -->
 <div class="modal fade" id="modalIngresarOrden" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header bg-success text-white">
-                <h5 class="modal-title">Ingresar Reporte de Servicio al Cliente</h5>
+                <h5 class="modal-title">Registrar Tarea</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body" id="contenidoOrden">
@@ -658,11 +658,11 @@ foreach ($columnas_ordenables as $col => $label):
 </div>
 <div class="row g-2 mb-4">
     <div class="col-12 col-md-auto">
-    <button id="btnExportarCSV" class="btn btn-dark btn-custom w-100">Exportar Resultados</button>
+    <button id="btnExportarCSV" class="btn btn-dark btn-custom w-100">Exportar Tareas (CSV)</button>
 </div>
 
 <div class="col-12 col-md-auto">
-  <a id="btnExportarPDF" class="btn btn-danger btn-custom w-100" href="#">Exportar PDF</a>
+  <a id="btnExportarPDF" class="btn btn-danger btn-custom w-100" href="#">Exportar Tareas (PDF)</a>
 </div>
 
     <div class="col-12 col-md-auto">
@@ -809,9 +809,9 @@ document.addEventListener("DOMContentLoaded", function () {
             .then(data => {
                 console.log("Respuesta JSON recibida:", data); // 73 Verifica en la consola
                 document.getElementById("kpi-summary-content").innerHTML = `
-                    <p><strong>Reportes de Servicio al Cliente Vencidas (Anual):</strong> $${data.foto_vencidas_anual}</p>
-                    <p><strong>Reportes de Servicio al Cliente Vencidas (Mes):</strong> $${data.foto_vencidas_mes}</p>
-                    <p><strong>Total de Reportes de Servicio al Cliente (Mes):</strong> $${data.foto_total_mes}</p>
+                    <p><strong>Tareas Vencidas (Anual):</strong> $${data.foto_vencidas_anual}</p>
+                    <p><strong>Tareas Vencidas (Mes):</strong> $${data.foto_vencidas_mes}</p>
+                    <p><strong>Total de Tareas del Mes:</strong> $${data.foto_total_mes}</p>
                     <p><strong>% Ordenes Liquidadas (Mes):</strong> ${data.porcentaje_liquidadas_mes}%</p>
                 `;
             })
@@ -1030,7 +1030,7 @@ document.addEventListener("DOMContentLoaded", function () {
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header bg-success text-white">
-                <h5 class="modal-title">Completar Orden</h5>
+                <h5 class="modal-title">Completar Tarea</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body" id="contenidoCompletarOrden">

--- a/ordenes_servicio_cliente.php
+++ b/ordenes_servicio_cliente.php
@@ -26,15 +26,15 @@ if (isset($_GET['modal'])) {
         </select>
     </div>
 
-    <!-- Fecha del reporte -->
+    <!-- Fecha de la Tarea -->
     <div class="mb-3">
-        <label for="fecha_reporte" class="form-label">Fecha del reporte</label>
+        <label for="fecha_reporte" class="form-label">Fecha de la Tarea</label>
         <input type="date" name="fecha_reporte" class="form-control" required>
     </div>
 
     <!-- Descripcin -->
     <div class="mb-3">
-        <label for="descripcion_reporte" class="form-label">Descripcin del Servicio al Cliente</label>
+        <label for="descripcion_reporte" class="form-label">Descripción de la Tarea</label>
         <textarea name="descripcion_reporte" class="form-control" required></textarea>
     </div>
 
@@ -51,7 +51,7 @@ if (isset($_GET['modal'])) {
 
     <!-- Subir foto -->
     <div class="mb-3">
-        <label for="foto" class="form-label">Subir foto del Servicio al Cliente</label>
+        <label for="foto" class="form-label">Subir foto de la Tarea</label>
         <input type="file" name="foto" class="form-control">
     </div>
 
@@ -109,7 +109,7 @@ if (isset($_GET['modal'])) {
 </div>
 
     <!-- Botn -->
-    <button type="submit" class="btn btn-success w-100">Guardar Reporte</button>
+    <button type="submit" class="btn btn-success w-100">Guardar Tarea</button>
 </form>
 <?php
     exit;


### PR DESCRIPTION
## Summary
- actualiza el menú principal y minipanel para mostrar **Tareas** en lugar de *Servicio al Cliente*
- ajusta encabezados y botones en páginas de KPIs y exportaciones
- modifica formularios y PDFs para reflejar la nueva denominación
- actualiza documentación de la aplicación

## Testing
- `grep -r "Servicio al Cliente" -n`

------
https://chatgpt.com/codex/tasks/task_e_686831ad9a848332b1180482d62cc8bf