### PR TITLE
Sync gasto exports with filters

### DIFF
--- a/exportar_gastos.php
+++ b/exportar_gastos.php
@@ -3,39 +3,83 @@ header('Content-Type: text/csv; charset=utf-8');
 header('Content-Disposition: attachment; filename=gastos.csv');
 include 'conexion.php';
 
-$cond = [];
-if (!empty($_GET['proveedor'])) {
-    $id = intval($_GET['proveedor']);
-    $cond[] = "g.proveedor_id=$id";
-}
-if (!empty($_GET['unidad'])) {
-    $id = intval($_GET['unidad']);
-    $cond[] = "g.unidad_negocio_id=$id";
-}
-if (!empty($_GET['fecha_inicio'])) {
-    $f = $conn->real_escape_string($_GET['fecha_inicio']);
-    $cond[] = "g.fecha_pago >= '$f'";
-}
-if (!empty($_GET['fecha_fin'])) {
-    $f = $conn->real_escape_string($_GET['fecha_fin']);
-    $cond[] = "g.fecha_pago <= '$f'";
-}
-if (!empty($_GET['estatus'])) {
-    $e = $conn->real_escape_string($_GET['estatus']);
-    $cond[] = "g.estatus='$e'";
-}
-if (!empty($_GET['origen'])) {
-    $o = $conn->real_escape_string($_GET['origen']);
-    $cond[] = "g.origen='$o'";
-}
-$where = $cond ? 'WHERE '.implode(' AND ',$cond) : '';
+$proveedor    = $_GET['proveedor'] ?? '';
+$unidad       = $_GET['unidad'] ?? '';
+$fecha_inicio = $_GET['fecha_inicio'] ?? '';
+$fecha_fin    = $_GET['fecha_fin'] ?? '';
+$estatus      = $_GET['estatus'] ?? '';
+$origen       = $_GET['origen'] ?? '';
+$orden        = $_GET['orden'] ?? 'fecha';
+$dir          = strtoupper($_GET['dir'] ?? 'DESC');
 
-$sql = "SELECT g.folio, p.nombre AS proveedor, g.monto, g.fecha_pago, un.nombre AS unidad, g.tipo_gasto, g.medio_pago, g.cuenta_bancaria, g.concepto, g.estatus FROM gastos g LEFT JOIN proveedores p ON g.proveedor_id=p.id LEFT JOIN unidades_negocio un ON g.unidad_negocio_id=un.id $where ORDER BY g.fecha_pago DESC";
+$cond = [];
+if ($proveedor !== '') { $cond[] = 'g.proveedor_id=' . intval($proveedor); }
+if ($unidad !== '') { $cond[] = 'g.unidad_negocio_id=' . intval($unidad); }
+if ($fecha_inicio !== '') { $cond[] = "g.fecha_pago >= '".$conn->real_escape_string($fecha_inicio)."'"; }
+if ($fecha_fin !== '') { $cond[] = "g.fecha_pago <= '".$conn->real_escape_string($fecha_fin)."'"; }
+if ($estatus !== '') { $cond[] = "g.estatus='".$conn->real_escape_string($estatus)."'"; }
+if ($origen !== '') { $cond[] = "g.origen='".$conn->real_escape_string($origen)."'"; }
+$where = $cond ? 'WHERE '.implode(' AND ', $cond) : '';
+
+$mapa_orden_sql = [
+    'folio'    => 'g.folio',
+    'proveedor'=> 'p.nombre',
+    'monto'    => 'g.monto',
+    'fecha'    => 'g.fecha_pago',
+    'unidad'   => 'un.nombre',
+    'tipo'     => 'g.tipo_gasto',
+    'tipo_compra' => 'g.tipo_compra',
+    'medio'    => 'g.medio_pago',
+    'cuenta'   => 'g.cuenta_bancaria',
+    'concepto' => 'g.concepto',
+    'estatus'  => 'g.estatus'
+];
+$columna_orden = $mapa_orden_sql[$orden] ?? 'g.fecha_pago';
+$dir = $dir === 'ASC' ? 'ASC' : 'DESC';
+
+$sql = "SELECT
+    g.folio,
+    p.nombre AS proveedor,
+    g.monto,
+    g.fecha_pago,
+    un.nombre AS unidad,
+    g.tipo_gasto,
+    g.tipo_compra,
+    g.medio_pago,
+    g.cuenta_bancaria,
+    g.concepto,
+    g.estatus,
+    g.origen,
+    (SELECT SUM(a.monto) FROM abonos_gastos a WHERE a.gasto_id = g.id) AS abonado_total,
+    (g.monto - IFNULL((SELECT SUM(a.monto) FROM abonos_gastos a WHERE a.gasto_id = g.id),0)) AS saldo,
+    (SELECT GROUP_CONCAT(a.archivo_comprobante SEPARATOR ';') FROM abonos_gastos a WHERE a.gasto_id = g.id AND a.archivo_comprobante IS NOT NULL) AS archivo_comprobante
+FROM gastos g
+LEFT JOIN proveedores p ON g.proveedor_id = p.id
+LEFT JOIN unidades_negocio un ON g.unidad_negocio_id = un.id
+$where
+ORDER BY $columna_orden $dir";
+
 $res = $conn->query($sql);
 $out = fopen('php://output','w');
-fputcsv($out,['Folio','Proveedor','Monto','Fecha','Unidad','Tipo','Medio','Cuenta','Concepto','Estatus']);
+fputcsv($out,['Folio','Proveedor','Monto','Abonado','Saldo','Fecha','Unidad','Tipo','Uso','Medio','Cuenta','Concepto','Estatus','Origen','Comprobantes']);
 while($row=$res->fetch_assoc()){
-    fputcsv($out,[$row['folio'],$row['proveedor'],$row['monto'],$row['fecha_pago'],$row['unidad'],$row['tipo_gasto'],$row['medio_pago'],$row['cuenta_bancaria'],$row['concepto'],$row['estatus']]);
+    fputcsv($out,[
+        $row['folio'],
+        $row['proveedor'],
+        $row['monto'],
+        $row['abonado_total'],
+        $row['saldo'],
+        $row['fecha_pago'],
+        $row['unidad'],
+        $row['tipo_gasto'],
+        $row['tipo_compra'],
+        $row['medio_pago'],
+        $row['cuenta_bancaria'],
+        $row['concepto'],
+        $row['estatus'],
+        $row['origen'],
+        $row['archivo_comprobante']
+    ]);
 }
 fclose($out);
 exit;

--- a/exportar_gastos_pdf.php
+++ b/exportar_gastos_pdf.php
@@ -3,51 +3,82 @@ require 'dompdf/autoload.inc.php';
 use Dompdf\Dompdf;
 include 'conexion.php';
 
-$cond = [];
-if (!empty($_GET['proveedor'])) {
-    $id = intval($_GET['proveedor']);
-    $cond[] = "g.proveedor_id=$id";
-}
-if (!empty($_GET['unidad'])) {
-    $id = intval($_GET['unidad']);
-    $cond[] = "g.unidad_negocio_id=$id";
-}
-if (!empty($_GET['fecha_inicio'])) {
-    $f = $conn->real_escape_string($_GET['fecha_inicio']);
-    $cond[] = "g.fecha_pago >= '$f'";
-}
-if (!empty($_GET['fecha_fin'])) {
-    $f = $conn->real_escape_string($_GET['fecha_fin']);
-    $cond[] = "g.fecha_pago <= '$f'";
-}
-if (!empty($_GET['estatus'])) {
-    $e = $conn->real_escape_string($_GET['estatus']);
-    $cond[] = "g.estatus='$e'";
-}
-if (!empty($_GET['origen'])) {
-    $o = $conn->real_escape_string($_GET['origen']);
-    $cond[] = "g.origen='$o'";
-}
-$where = $cond ? 'WHERE '.implode(' AND ',$cond) : '';
+$proveedor    = $_GET['proveedor'] ?? '';
+$unidad       = $_GET['unidad'] ?? '';
+$fecha_inicio = $_GET['fecha_inicio'] ?? '';
+$fecha_fin    = $_GET['fecha_fin'] ?? '';
+$estatus      = $_GET['estatus'] ?? '';
+$origen       = $_GET['origen'] ?? '';
+$orden        = $_GET['orden'] ?? 'fecha';
+$dir          = strtoupper($_GET['dir'] ?? 'DESC');
 
-$sql = "SELECT g.folio, p.nombre AS proveedor, g.monto, g.fecha_pago, un.nombre AS unidad, g.tipo_gasto, g.medio_pago, g.cuenta_bancaria, g.concepto, g.estatus FROM gastos g LEFT JOIN proveedores p ON g.proveedor_id=p.id LEFT JOIN unidades_negocio un ON g.unidad_negocio_id=un.id $where ORDER BY g.fecha_pago DESC";
+$cond = [];
+if ($proveedor !== '') { $cond[] = 'g.proveedor_id=' . intval($proveedor); }
+if ($unidad !== '') { $cond[] = 'g.unidad_negocio_id=' . intval($unidad); }
+if ($fecha_inicio !== '') { $cond[] = "g.fecha_pago >= '".$conn->real_escape_string($fecha_inicio)."'"; }
+if ($fecha_fin !== '') { $cond[] = "g.fecha_pago <= '".$conn->real_escape_string($fecha_fin)."'"; }
+if ($estatus !== '') { $cond[] = "g.estatus='".$conn->real_escape_string($estatus)."'"; }
+if ($origen !== '') { $cond[] = "g.origen='".$conn->real_escape_string($origen)."'"; }
+$where = $cond ? 'WHERE '.implode(' AND ', $cond) : '';
+
+$mapa_orden_sql = [
+    'folio'    => 'g.folio',
+    'proveedor'=> 'p.nombre',
+    'monto'    => 'g.monto',
+    'fecha'    => 'g.fecha_pago',
+    'unidad'   => 'un.nombre',
+    'tipo'     => 'g.tipo_gasto',
+    'tipo_compra' => 'g.tipo_compra',
+    'medio'    => 'g.medio_pago',
+    'cuenta'   => 'g.cuenta_bancaria',
+    'concepto' => 'g.concepto',
+    'estatus'  => 'g.estatus'
+];
+$columna_orden = $mapa_orden_sql[$orden] ?? 'g.fecha_pago';
+$dir = $dir === 'ASC' ? 'ASC' : 'DESC';
+
+$sql = "SELECT
+    g.folio,
+    p.nombre AS proveedor,
+    g.monto,
+    g.fecha_pago,
+    un.nombre AS unidad,
+    g.tipo_gasto,
+    g.tipo_compra,
+    g.medio_pago,
+    g.cuenta_bancaria,
+    g.concepto,
+    g.estatus,
+    g.origen,
+    (SELECT SUM(a.monto) FROM abonos_gastos a WHERE a.gasto_id = g.id) AS abonado_total,
+    (g.monto - IFNULL((SELECT SUM(a.monto) FROM abonos_gastos a WHERE a.gasto_id = g.id),0)) AS saldo,
+    (SELECT GROUP_CONCAT(a.archivo_comprobante SEPARATOR ';') FROM abonos_gastos a WHERE a.gasto_id = g.id AND a.archivo_comprobante IS NOT NULL) AS archivo_comprobante
+FROM gastos g
+LEFT JOIN proveedores p ON g.proveedor_id = p.id
+LEFT JOIN unidades_negocio un ON g.unidad_negocio_id = un.id
+$where
+ORDER BY $columna_orden $dir";
 $res = $conn->query($sql);
 
 $html = '<h3 style="text-align:center;font-weight:bold;">Reporte de Gastos</h3>';
 $html .= '<table border="1" cellspacing="0" cellpadding="4" width="100%" style="font-size:10px">';
-$html .= '<thead><tr><th>Folio</th><th>Proveedor</th><th>Monto</th><th>Fecha</th><th>Unidad</th><th>Tipo</th><th>Medio</th><th>Cuenta</th><th>Concepto</th><th>Estatus</th></tr></thead><tbody>';
+$html .= '<thead><tr><th>Folio</th><th>Proveedor</th><th>Monto</th><th>Abonado</th><th>Saldo</th><th>Fecha</th><th>Unidad</th><th>Tipo</th><th>Uso</th><th>Medio</th><th>Cuenta</th><th>Concepto</th><th>Estatus</th><th>Origen</th></tr></thead><tbody>';
 while($row=$res->fetch_assoc()){
     $html .= '<tr>';
     $html .= '<td>'.htmlspecialchars($row['folio']).'</td>';
     $html .= '<td>'.htmlspecialchars($row['proveedor']).'</td>';
     $html .= '<td>$'.number_format($row['monto'],2).'</td>';
+    $html .= '<td>$'.number_format($row['abonado_total'],2).'</td>';
+    $html .= '<td>$'.number_format($row['saldo'],2).'</td>';
     $html .= '<td>'.htmlspecialchars($row['fecha_pago']).'</td>';
     $html .= '<td>'.htmlspecialchars($row['unidad']).'</td>';
     $html .= '<td>'.htmlspecialchars($row['tipo_gasto']).'</td>';
+    $html .= '<td>'.htmlspecialchars($row['tipo_compra']).'</td>';
     $html .= '<td>'.htmlspecialchars($row['medio_pago']).'</td>';
     $html .= '<td>'.htmlspecialchars($row['cuenta_bancaria']).'</td>';
     $html .= '<td>'.htmlspecialchars($row['concepto']).'</td>';
     $html .= '<td>'.htmlspecialchars($row['estatus']).'</td>';
+    $html .= '<td>'.htmlspecialchars($row['origen']).'</td>';
     $html .= '</tr>';
 }
 $html .= '</tbody></table>';

--- a/gastos.php
+++ b/gastos.php
@@ -278,7 +278,9 @@ $comps = [];
 while ($row = $resComps->fetch_assoc()) {
     $comps[] = $row['archivo_comprobante'];
 }
-if (count($comps)) {
+if (count($comps) === 1) {
+    echo '<a href="' . htmlspecialchars($comps[0]) . '" target="_blank" class="btn btn-sm btn-outline-secondary">Ver</a>';
+} elseif (count($comps) > 1) {
     echo '<button class="btn btn-sm btn-outline-secondary ver-comprobantes-btn" data-id="' . $g['id'] . '">Ver</button>';
 } else {
     echo '<span class="text-muted">Sin archivo</span>';

--- a/generar_pdf_gasto.php
+++ b/generar_pdf_gasto.php
@@ -6,7 +6,11 @@ include 'conexion.php';
 $folio = $_GET['folio'] ?? '';
 if (!$folio) { die('Folio no proporcionado'); }
 
-$sql = "SELECT g.folio, p.nombre AS proveedor, g.monto, g.fecha_pago, un.nombre AS unidad, g.tipo_gasto, g.medio_pago, g.cuenta_bancaria, g.estatus, g.concepto FROM gastos g LEFT JOIN proveedores p ON g.proveedor_id=p.id LEFT JOIN unidades_negocio un ON g.unidad_negocio_id=un.id WHERE g.folio=?";
+$sql = "SELECT g.folio, p.nombre AS proveedor, un.nombre AS unidad, g.monto, g.fecha_pago, g.estatus, g.medio_pago, g.cuenta_bancaria, g.concepto
+        FROM gastos g
+        LEFT JOIN proveedores p ON g.proveedor_id=p.id
+        LEFT JOIN unidades_negocio un ON g.unidad_negocio_id=un.id
+        WHERE g.folio=?";
 $stmt = $conn->prepare($sql);
 $stmt->bind_param('s',$folio);
 $stmt->execute();
@@ -14,12 +18,34 @@ $res = $stmt->get_result();
 if($res->num_rows===0){ die('Registro no encontrado'); }
 $row = $res->fetch_assoc();
 
+$comp = $conn->query("SELECT archivo_comprobante FROM abonos_gastos WHERE gasto_id = (SELECT id FROM gastos WHERE folio='".$conn->real_escape_string($folio)."') AND archivo_comprobante IS NOT NULL ORDER BY id ASC");
+$archivos = [];
+while($r=$comp->fetch_assoc()){ $archivos[] = $r['archivo_comprobante']; }
+
 $html = '<h3 style="text-align:center;font-weight:bold;">Detalle de Gasto</h3>';
 $html .= '<table border="1" cellspacing="0" cellpadding="4" width="100%" style="font-size:12px">';
-foreach($row as $k=>$v){
-    $html .= '<tr><td><strong>'.htmlspecialchars($k).'</strong></td><td>'.htmlspecialchars($v).'</td></tr>';
-}
+$html .= '<tr><td><strong>Folio</strong></td><td>'.htmlspecialchars($row['folio']).'</td></tr>';
+$html .= '<tr><td><strong>Proveedor</strong></td><td>'.htmlspecialchars($row['proveedor']).'</td></tr>';
+$html .= '<tr><td><strong>Unidad</strong></td><td>'.htmlspecialchars($row['unidad']).'</td></tr>';
+$html .= '<tr><td><strong>Monto</strong></td><td>$'.number_format($row['monto'],2).'</td></tr>';
+$html .= '<tr><td><strong>Fecha</strong></td><td>'.htmlspecialchars($row['fecha_pago']).'</td></tr>';
+$html .= '<tr><td><strong>Estatus</strong></td><td>'.htmlspecialchars($row['estatus']).'</td></tr>';
+$html .= '<tr><td><strong>Medio de pago</strong></td><td>'.htmlspecialchars($row['medio_pago']).'</td></tr>';
+$html .= '<tr><td><strong>Cuenta</strong></td><td>'.htmlspecialchars($row['cuenta_bancaria']).'</td></tr>';
+$html .= '<tr><td><strong>Concepto</strong></td><td>'.htmlspecialchars($row['concepto']).'</td></tr>';
 $html .= '</table>';
+
+if(count($archivos)){
+    $html .= '<h4>Comprobantes</h4>';
+    foreach($archivos as $a){
+        $is_pdf = preg_match('/\.pdf$/i',$a);
+        if($is_pdf){
+            $html .= '<div><a href="'.htmlspecialchars($a).'">'.basename($a).'</a></div>';
+        }else{
+            $html .= '<div><img src="'.htmlspecialchars($a).'" style="max-width:500px;max-height:400px;"></div>';
+        }
+    }
+}
 
 $dompdf = new Dompdf();
 $dompdf->loadHtml($html);


### PR DESCRIPTION
## Summary
- sync `exportar_gastos.php` and `exportar_gastos_pdf.php` with filtering logic from `gastos.php`
- enhance `generar_pdf_gasto.php` to show detailed info and comprobantes
- improve "Ver" button in `gastos.php` when only one comprobante

## Testing
- `php -l exportar_gastos.php`
- `php -l exportar_gastos_pdf.php`
- `php -l generar_pdf_gasto.php`
- `php -l gastos.php`


------
https://chatgpt.com/codex/tasks/task_e_686892e5f0b0833292ab03621f8054ce