### PR TITLE
Enforce authentication on gasto scripts

### DIFF
--- a/guardar_abono_gasto.php
+++ b/guardar_abono_gasto.php
@@ -1,4 +1,5 @@
 <?php
+include 'auth.php';
 include 'conexion.php';
 
 $gasto_id = intval($_POST['gasto_id'] ?? 0);

--- a/guardar_gasto.php
+++ b/guardar_gasto.php
@@ -1,6 +1,6 @@
 <?php
+include 'auth.php';
 include 'conexion.php';
-session_start();
 
 // Mostrar errores (modo desarrollo)
 ini_set('display_errors', 1);


### PR DESCRIPTION
## Summary
- ensure gasto saving routes check session

## Testing
- `php -l guardar_gasto.php`
- `php -l guardar_abono_gasto.php`


------
https://chatgpt.com/codex/tasks/task_e_68754c7c3010833283f9983d2156d820