### PR TITLE
Add auth check to expense handlers

### DIFF
--- a/guardar_abono_gasto.php
+++ b/guardar_abono_gasto.php
@@ -1,4 +1,6 @@
 <?php
+session_start();
+include 'auth.php';
 include 'conexion.php';
 
 $gasto_id = intval($_POST['gasto_id'] ?? 0);

--- a/guardar_gasto.php
+++ b/guardar_gasto.php
@@ -1,6 +1,7 @@
 <?php
-include 'conexion.php';
 session_start();
+include 'auth.php';
+include 'conexion.php';
 
 // Mostrar errores (modo desarrollo)
 ini_set('display_errors', 1);


### PR DESCRIPTION
## Summary
- require authentication for gastos forms

## Testing
- `php -l guardar_gasto.php`
- `php -l guardar_abono_gasto.php`


------
https://chatgpt.com/codex/tasks/task_e_68754e1990b8833284ad2192f5e226c6