### PR TITLE
Fix comprobante deletion path

### DIFF
--- a/conexion.php
+++ b/conexion.php
@@ -18,7 +18,13 @@ mysqli_query($conn, "SET SESSION collation_connection = 'utf8mb4_unicode_ci'");
 
 
 if ($conn->connect_error) {
-    die("Error de conexión a la base de datos: " . $conn->connect_error);
+if (!defined('UPLOADS_DIR')) {
+    define('UPLOADS_DIR', 'uploads');
+}
+if (!defined('COMPROBANTES_DIR')) {
+    define('COMPROBANTES_DIR', UPLOADS_DIR . '/comprobantes');
+}
+    die("Error de conexiÃ³n a la base de datos: " . $conn->connect_error);
 }
 
 ?>

--- a/eliminar_gasto.php
+++ b/eliminar_gasto.php
@@ -18,8 +18,8 @@ if (!$id) {
 $res = $conn->query("SELECT archivo_comprobante FROM abonos_gastos WHERE gasto_id = $id AND archivo_comprobante IS NOT NULL");
 while ($row = $res->fetch_assoc()) {
     $archivo = $row['archivo_comprobante'];
-    if ($archivo && file_exists("comprobantes/$archivo")) {
-        unlink("comprobantes/$archivo");
+    if ($archivo && file_exists(COMPROBANTES_DIR . "/$archivo")) {
+        unlink(COMPROBANTES_DIR . "/$archivo");
     }
 }
 


### PR DESCRIPTION
## Summary
- update comprobante deletion path to use uploads directory
- define constants for uploads and comprobantes folders

## Testing
- `php -l eliminar_gasto.php`
- `php -l conexion.php`


------
https://chatgpt.com/codex/tasks/task_e_6875519e53108332abf7484d258a9737