### PR TITLE
Load DB config from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_HOST=localhost
+DB_USER=user
+DB_PASSWORD=password
+DB_NAME=database

--- a/conexion.php
+++ b/conexion.php
@@ -1,9 +1,22 @@
 <?php
+// Cargar variables de entorno desde .env si existe
+$envFile = __DIR__ . '/.env';
+if (file_exists($envFile)) {
+    foreach (file($envFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
+        $line = trim($line);
+        if ($line === '' || strpos($line, '#') === 0 || strpos($line, '=') === false) {
+            continue;
+        }
+        list($key, $value) = explode('=', $line, 2);
+        $_ENV[trim($key)] = trim($value);
+    }
+}
+
 //  Configuracion de la Base de Datos
-$servername = "localhost";
-$username   = "corazon_caribe";
-$password   = "Kantun.01*";
-$database   = "corazon_orderdecompras";
+$servername = $_ENV['DB_HOST'] ?? 'localhost';
+$username   = $_ENV['DB_USER'] ?? 'user';
+$password   = $_ENV['DB_PASSWORD'] ?? 'password';
+$database   = $_ENV['DB_NAME'] ?? 'database';
 
 // Crear conexion
 $conn = new mysqli($servername, $username, $password, $database);

--- a/listar_usuarios.php
+++ b/listar_usuarios.php
@@ -1,18 +1,12 @@
 <?php
 include 'auth.php';
 verificar_rol('superadmin'); // Solo superadministradores pueden acceder
-include 'conexion.php'; // Ahora usa el archivo de conexión
+include 'conexion.php'; // Usa la conexión centralizada
 header('Content-Type: text/html; charset=utf-8');
 
 // Verificar si el usuario es superadmin
 if (!isset($_SESSION['user_id']) || $_SESSION['user_role'] !== 'superadmin') {
     die("Acceso no autorizado.");
-}
-
-$conn = new mysqli($servername, $username, $password, $database);
-
-if ($conn->connect_error) {
-    die("Conexión fallida: " . $conn->connect_error);
 }
 
 // Obtener usuarios


### PR DESCRIPTION
## Summary
- add `.env.example` template
- load environment variables in `conexion.php`
- rely on centralized connection in `listar_usuarios.php`

## Testing
- `php -l conexion.php`
- `php -l listar_usuarios.php`


------
https://chatgpt.com/codex/tasks/task_e_68827d30b8c883329e104e056c794b63