### PR TITLE
Secure query handling and logging

### DIFF
--- a/cargar_mantenimiento.php
+++ b/cargar_mantenimiento.php
@@ -7,15 +7,22 @@ $registros_por_pagina = 100;
 $pagina_actual = isset($_GET['pagina']) ? (int)$_GET['pagina'] : 1;
 $offset = ($pagina_actual - 1) * $registros_por_pagina;
 
-$query = "SELECT folio, monto, vencimiento_pago, concepto_pago, tipo_pago, genera_factura, estatus_pago, quien_pago_id, nivel,
-                 (SELECT nombre FROM proveedores WHERE id = proveedor_id) AS proveedor, 
-                 (SELECT nombre FROM usuarios WHERE id = usuario_solicitante_id) AS usuario,
-                 (SELECT nombre FROM unidades_negocio WHERE id = unidad_negocio_id) AS unidad_negocio
-          FROM ordenes_compra 
-          ORDER BY fecha_creacion DESC 
-          LIMIT $registros_por_pagina OFFSET $offset";
+$sql = "SELECT folio, monto, vencimiento_pago, concepto_pago, tipo_pago, genera_factura, estatus_pago, quien_pago_id, nivel,
+                (SELECT nombre FROM proveedores WHERE id = proveedor_id) AS proveedor,
+                (SELECT nombre FROM usuarios WHERE id = usuario_solicitante_id) AS usuario,
+                (SELECT nombre FROM unidades_negocio WHERE id = unidad_negocio_id) AS unidad_negocio
+        FROM ordenes_compra
+        ORDER BY fecha_creacion DESC
+        LIMIT ? OFFSET ?";
 
-$ordenes = $conn->query($query);
+$stmt = $conn->prepare($sql);
+if (!$stmt) {
+    log_error('Error al preparar consulta en cargar_mantenimiento: ' . $conn->error);
+    exit;
+}
+$stmt->bind_param('ii', $registros_por_pagina, $offset);
+$stmt->execute();
+$ordenes = $stmt->get_result();
 
 while ($orden = $ordenes->fetch_assoc()): ?>
     <tr>

--- a/cargar_ordenes.php
+++ b/cargar_ordenes.php
@@ -7,15 +7,22 @@ $registros_por_pagina = 100;
 $pagina_actual = isset($_GET['pagina']) ? (int)$_GET['pagina'] : 1;
 $offset = ($pagina_actual - 1) * $registros_por_pagina;
 
-$query = "SELECT folio, monto, vencimiento_pago, concepto_pago, tipo_pago, genera_factura, estatus_pago, quien_pago_id, nivel,
-                 (SELECT nombre FROM proveedores WHERE id = proveedor_id) AS proveedor, 
-                 (SELECT nombre FROM usuarios WHERE id = usuario_solicitante_id) AS usuario,
-                 (SELECT nombre FROM unidades_negocio WHERE id = unidad_negocio_id) AS unidad_negocio
-          FROM ordenes_compra 
-          ORDER BY fecha_creacion DESC 
-          LIMIT $registros_por_pagina OFFSET $offset";
+$sql = "SELECT folio, monto, vencimiento_pago, concepto_pago, tipo_pago, genera_factura, estatus_pago, quien_pago_id, nivel,
+                (SELECT nombre FROM proveedores WHERE id = proveedor_id) AS proveedor,
+                (SELECT nombre FROM usuarios WHERE id = usuario_solicitante_id) AS usuario,
+                (SELECT nombre FROM unidades_negocio WHERE id = unidad_negocio_id) AS unidad_negocio
+        FROM ordenes_compra
+        ORDER BY fecha_creacion DESC
+        LIMIT ? OFFSET ?";
 
-$ordenes = $conn->query($query);
+$stmt = $conn->prepare($sql);
+if (!$stmt) {
+    log_error('Error al preparar consulta en cargar_ordenes: ' . $conn->error);
+    exit;
+}
+$stmt->bind_param('ii', $registros_por_pagina, $offset);
+$stmt->execute();
+$ordenes = $stmt->get_result();
 
 while ($orden = $ordenes->fetch_assoc()): ?>
     <tr>

--- a/cargar_servicio_cliente.php
+++ b/cargar_servicio_cliente.php
@@ -7,15 +7,22 @@ $registros_por_pagina = 100;
 $pagina_actual = isset($_GET['pagina']) ? (int)$_GET['pagina'] : 1;
 $offset = ($pagina_actual - 1) * $registros_por_pagina;
 
-$query = "SELECT folio, monto, vencimiento_pago, concepto_pago, tipo_pago, genera_factura, estatus_pago, quien_pago_id, nivel,
-                 (SELECT nombre FROM proveedores WHERE id = proveedor_id) AS proveedor, 
-                 (SELECT nombre FROM usuarios WHERE id = usuario_solicitante_id) AS usuario,
-                 (SELECT nombre FROM unidades_negocio WHERE id = unidad_negocio_id) AS unidad_negocio
-          FROM ordenes_compra 
-          ORDER BY fecha_creacion DESC 
-          LIMIT $registros_por_pagina OFFSET $offset";
+$sql = "SELECT folio, monto, vencimiento_pago, concepto_pago, tipo_pago, genera_factura, estatus_pago, quien_pago_id, nivel,
+                (SELECT nombre FROM proveedores WHERE id = proveedor_id) AS proveedor,
+                (SELECT nombre FROM usuarios WHERE id = usuario_solicitante_id) AS usuario,
+                (SELECT nombre FROM unidades_negocio WHERE id = unidad_negocio_id) AS unidad_negocio
+        FROM ordenes_compra
+        ORDER BY fecha_creacion DESC
+        LIMIT ? OFFSET ?";
 
-$ordenes = $conn->query($query);
+$stmt = $conn->prepare($sql);
+if (!$stmt) {
+    log_error('Error al preparar consulta en cargar_servicio_cliente: ' . $conn->error);
+    exit;
+}
+$stmt->bind_param('ii', $registros_por_pagina, $offset);
+$stmt->execute();
+$ordenes = $stmt->get_result();
 
 while ($orden = $ordenes->fetch_assoc()): ?>
     <tr>

--- a/includes/controllers/analisis_kpis_gastos.php
+++ b/includes/controllers/analisis_kpis_gastos.php
@@ -14,19 +14,61 @@ if (!$fecha_inicio || !$fecha_fin) {
 }
 
 // Condición SQL
-$cond = [];
-$cond[] = "fecha_pago BETWEEN '$fecha_inicio' AND '$fecha_fin'";
+$cond = ["fecha_pago BETWEEN ? AND ?"];
+$params = [$fecha_inicio, $fecha_fin];
+$types  = 'ss';
 if (!empty($unidad_id)) {
-    $cond[] = "unidad_negocio_id = " . intval($unidad_id);
+    $cond[]  = "unidad_negocio_id = ?";
+    $params[] = (int)$unidad_id;
+    $types   .= 'i';
 }
 $where = 'WHERE ' . implode(' AND ', $cond);
 
+function fetch_value(mysqli $conn, string $sql, string $types, array $params) {
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) {
+        log_error('Error al preparar consulta en analisis_kpis_gastos: ' . $conn->error);
+        return 0;
+    }
+    if ($types) {
+        $stmt->bind_param($types, ...$params);
+    }
+    if (!$stmt->execute()) {
+        log_error('Error al ejecutar consulta en analisis_kpis_gastos: ' . $stmt->error);
+        $stmt->close();
+        return 0;
+    }
+    $res = $stmt->get_result();
+    $val = $res ? ($res->fetch_assoc()['total'] ?? 0) : 0;
+    $stmt->close();
+    return $val;
+}
+
+function fetch_all(mysqli $conn, string $sql, string $types, array $params) {
+    $stmt = $conn->prepare($sql);
+    if (!$stmt) {
+        log_error('Error al preparar consulta en analisis_kpis_gastos: ' . $conn->error);
+        return false;
+    }
+    if ($types) {
+        $stmt->bind_param($types, ...$params);
+    }
+    if (!$stmt->execute()) {
+        log_error('Error al ejecutar consulta en analisis_kpis_gastos: ' . $stmt->error);
+        $stmt->close();
+        return false;
+    }
+    $res = $stmt->get_result();
+    $stmt->close();
+    return $res;
+}
+
 // 1. Gasto total
-$total = $conn->query("SELECT SUM(monto) AS total FROM gastos $where")->fetch_assoc()['total'] ?? 0;
+$total = fetch_value($conn, "SELECT SUM(monto) AS total FROM gastos $where", $types, $params);
 
 // 2. Por tipo
 $tipos = [];
-$res = $conn->query("SELECT tipo_gasto, SUM(monto) AS total FROM gastos $where GROUP BY tipo_gasto");
+$res = fetch_all($conn, "SELECT tipo_gasto, SUM(monto) AS total FROM gastos $where GROUP BY tipo_gasto", $types, $params);
 while ($row = $res->fetch_assoc()) {
     $tipo = trim($row['tipo_gasto']) ?: 'Sin tipo';
     $tipos[] = ['tipo' => $tipo, 'total' => (float)$row['total']];
@@ -34,10 +76,12 @@ while ($row = $res->fetch_assoc()) {
 
 // 3. Por unidad
 $unidades = [];
-$res = $conn->query("SELECT un.nombre AS unidad, SUM(g.monto) AS total 
-    FROM gastos g 
-    LEFT JOIN unidades_negocio un ON g.unidad_negocio_id = un.id
-    $where GROUP BY un.nombre");
+$res = fetch_all(
+    $conn,
+    "SELECT un.nombre AS unidad, SUM(g.monto) AS total FROM gastos g LEFT JOIN unidades_negocio un ON g.unidad_negocio_id = un.id $where GROUP BY un.nombre",
+    $types,
+    $params
+);
 while ($row = $res->fetch_assoc()) {
     $unidad = trim($row['unidad']) ?: 'Sin unidad';
     $unidades[] = ['unidad' => $unidad, 'total' => (float)$row['total']];
@@ -45,7 +89,7 @@ while ($row = $res->fetch_assoc()) {
 
 // 4. Por estatus
 $estatus = [];
-$res = $conn->query("SELECT estatus, SUM(monto) AS total FROM gastos $where GROUP BY estatus");
+$res = fetch_all($conn, "SELECT estatus, SUM(monto) AS total FROM gastos $where GROUP BY estatus", $types, $params);
 while ($row = $res->fetch_assoc()) {
     $est = trim($row['estatus']) ?: 'Sin estatus';
     $estatus[] = ['estatus' => $est, 'total' => (float)$row['total']];
@@ -53,20 +97,31 @@ while ($row = $res->fetch_assoc()) {
 
 // 5. Por proveedor
 $proveedores = [];
-$res = $conn->query("SELECT p.nombre AS proveedor, SUM(g.monto) AS total 
-    FROM gastos g 
-    LEFT JOIN proveedores p ON g.proveedor_id = p.id
-    $where GROUP BY p.nombre");
+$res = fetch_all(
+    $conn,
+    "SELECT p.nombre AS proveedor, SUM(g.monto) AS total FROM gastos g LEFT JOIN proveedores p ON g.proveedor_id = p.id $where GROUP BY p.nombre",
+    $types,
+    $params
+);
 while ($row = $res->fetch_assoc()) {
     $prov = trim($row['proveedor']) ?: 'Sin proveedor';
     $proveedores[] = ['proveedor' => $prov, 'total' => (float)$row['total']];
 }
 
 // 6. Abonos vs Saldo
-$abonos = $conn->query("SELECT 
+$stmt = $conn->prepare("SELECT
     SUM(IFNULL((SELECT SUM(a.monto) FROM abonos_gastos a WHERE a.gasto_id = g.id), 0)) AS abonado,
     SUM(g.monto - IFNULL((SELECT SUM(a.monto) FROM abonos_gastos a WHERE a.gasto_id = g.id), 0)) AS saldo
-    FROM gastos g $where")->fetch_assoc();
+    FROM gastos g $where");
+if ($stmt) {
+    $stmt->bind_param($types, ...$params);
+    $stmt->execute();
+    $abonos = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+} else {
+    log_error('Error al preparar consulta en analisis_kpis_gastos: ' . $conn->error);
+    $abonos = ['abonado'=>0,'saldo'=>0];
+}
 
 // Respuesta
 $response = [

--- a/utils.php
+++ b/utils.php
@@ -13,4 +13,13 @@ function registrar_actividad($conn, $usuario_id, $accion) {
     $stmt->execute();
     $stmt->close();
 }
+
+/**
+ * Registra un mensaje de error en un archivo y en el log de PHP
+ */
+function log_error(string $message, string $file = 'app_error.log'): void {
+    $entry = sprintf("[%s] %s\n", date('Y-m-d H:i:s'), $message);
+    error_log($entry, 3, $file);
+    error_log($message);
+}
 ?>


### PR DESCRIPTION
## Summary
- add `log_error` helper to centralize error logging
- refactor paginated loaders to use prepared statements
- secure delegate update with bound parameters
- use prepared queries in KPI analysis controller

## Testing
- `php -l utils.php`
- `php -l cargar_mantenimiento.php`
- `php -l cargar_ordenes.php`
- `php -l cargar_servicio_cliente.php`
- `php -l actualizar_delegado_servicio_cliente.php`
- `php -l includes/controllers/analisis_kpis_gastos.php`

------
https://chatgpt.com/codex/tasks/task_e_6882a93368048332a68c0e284dbfd08b