### PR TITLE
Sanitize displayed DB values

### DIFF
--- a/app/components/PanelResumen.php
+++ b/app/components/PanelResumen.php
@@ -13,10 +13,10 @@ class PanelResumen {
     }
 
     public function render(): void {
-        echo '<h2>'.htmlspecialchars($this->title)."</h2>\n";
+        echo '<h2>'.htmlspecialchars($this->title, ENT_QUOTES, 'UTF-8')."</h2>\n";
         echo '<div class="row mb-3">';
         foreach ($this->kpis as $label => $value) {
-            echo '<div class="col"><strong>'.htmlspecialchars($label).':</strong> '.htmlspecialchars((string)$value).'</div>';
+            echo '<div class="col"><strong>'.htmlspecialchars($label, ENT_QUOTES, 'UTF-8').':</strong> '.htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8').'</div>';
         }
         echo '</div>';
 
@@ -24,13 +24,13 @@ class PanelResumen {
         if (!empty($this->data)) {
             echo '<thead><tr>'; 
             foreach (array_keys($this->data[0]) as $col) {
-                echo '<th>'.htmlspecialchars($col).'</th>';
+                echo '<th>'.htmlspecialchars($col, ENT_QUOTES, 'UTF-8').'</th>';
             }
             echo '</tr></thead><tbody>';
             foreach ($this->data as $row) {
                 echo '<tr>'; 
                 foreach ($row as $cell) {
-                    echo '<td>'.htmlspecialchars((string)$cell).'</td>';
+                    echo '<td>'.htmlspecialchars((string)$cell, ENT_QUOTES, 'UTF-8').'</td>';
                 }
                 echo '</tr>';
             }

--- a/kpis.php
+++ b/kpis.php
@@ -67,7 +67,7 @@ $ordenes_por_tipo_pago = $conn->query("SELECT tipo_pago, SUM(monto) AS total FRO
         new Chart(document.getElementById('chartEstatus').getContext('2d'), {
             type: 'bar',
             data: { 
-                labels: [<?php while ($row = $ordenes_por_estatus->fetch_assoc()) echo "'".$row['estatus_pago']."',"; ?>], 
+                labels: [<?php while ($row = $ordenes_por_estatus->fetch_assoc()) echo "'".htmlspecialchars($row['estatus_pago'], ENT_QUOTES, 'UTF-8')."',"; ?>],
                 datasets: [{
                     label: 'Monto ($)',
                     data: [<?php $ordenes_por_estatus->data_seek(0); while ($row = $ordenes_por_estatus->fetch_assoc()) echo $row['total'].","; ?>],
@@ -79,7 +79,7 @@ $ordenes_por_tipo_pago = $conn->query("SELECT tipo_pago, SUM(monto) AS total FRO
         new Chart(document.getElementById('chartTipoPago').getContext('2d'), {
             type: 'pie',
             data: { 
-                labels: [<?php while ($row = $ordenes_por_tipo_pago->fetch_assoc()) echo "'".$row['tipo_pago']."',"; ?>], 
+                labels: [<?php while ($row = $ordenes_por_tipo_pago->fetch_assoc()) echo "'".htmlspecialchars($row['tipo_pago'], ENT_QUOTES, 'UTF-8')."',"; ?>],
                 datasets: [{
                     data: [<?php $ordenes_por_tipo_pago->data_seek(0); while ($row = $ordenes_por_tipo_pago->fetch_assoc()) echo $row['total'].","; ?>],
                     backgroundColor: ['#FF6384', '#36A2EB', '#FFCE56']

--- a/kpis_mantenimiento_printable.php
+++ b/kpis_mantenimiento_printable.php
@@ -38,7 +38,9 @@ $kpis = include 'kpis_mantenimiento_data_core.php';
   <div class="row g-4 mb-4">
     <?php
     function card($label, $valor, $color) {
-      echo "<div class='col-md-4'><div class='card-kpi text-$color'><h6>$label</h6><h3>$valor</h3></div></div>";
+      $label = htmlspecialchars($label, ENT_QUOTES, 'UTF-8');
+      $valor = htmlspecialchars((string)$valor, ENT_QUOTES, 'UTF-8');
+      echo "<div class='col-md-4'><div class='card-kpi text-$color'><h6>{$label}</h6><h3>{$valor}</h3></div></div>";
     }
     card('Total Reportes', $kpis['total'], 'primary');
     card('Pendientes', $kpis['pendientes'], 'secondary');

--- a/kpis_servicio_cliente_printable.php
+++ b/kpis_servicio_cliente_printable.php
@@ -38,7 +38,9 @@ $kpis = include 'kpis_servicio_cliente_data_core.php';
   <div class="row g-4 mb-4">
     <?php
     function card($label, $valor, $color) {
-      echo "<div class='col-md-4'><div class='card-kpi text-$color'><h6>$label</h6><h3>$valor</h3></div></div>";
+      $label = htmlspecialchars($label, ENT_QUOTES, 'UTF-8');
+      $valor = htmlspecialchars((string)$valor, ENT_QUOTES, 'UTF-8');
+      echo "<div class='col-md-4'><div class='card-kpi text-$color'><h6>{$label}</h6><h3>{$valor}</h3></div></div>";
     }
     card('Solicitudes Totales', $kpis['total'], 'primary');
     card('En Espera', $kpis['pendientes'], 'secondary');

--- a/modal_comprobantes.php
+++ b/modal_comprobantes.php
@@ -19,14 +19,14 @@ if (empty($comprobantes)) {
 <div class="modal-body p-0">
     <div id="carouselComprobantes" class="carousel slide" data-bs-ride="carousel">
         <div class="carousel-inner">
-            <?php foreach ($comprobantes as $i => $ruta): 
+            <?php foreach ($comprobantes as $i => $ruta):
                 $is_pdf = preg_match('/\.pdf$/i', $ruta);
             ?>
             <div class="carousel-item <?php if($i === 0) echo 'active'; ?>">
                 <?php if ($is_pdf): ?>
-                    <iframe src="<?php echo htmlspecialchars($ruta); ?>" class="w-100" style="height:500px;border:none;"></iframe>
+                    <iframe src="<?php echo htmlspecialchars($ruta, ENT_QUOTES, 'UTF-8'); ?>" class="w-100" style="height:500px;border:none;"></iframe>
                 <?php else: ?>
-                    <img src="<?php echo htmlspecialchars($ruta); ?>" class="d-block w-100" style="max-height:500px;object-fit:contain;">
+                    <img src="<?php echo htmlspecialchars($ruta, ENT_QUOTES, 'UTF-8'); ?>" class="d-block w-100" style="max-height:500px;object-fit:contain;">
                 <?php endif; ?>
             </div>
             <?php endforeach; ?>

--- a/modal_editar_orden.php
+++ b/modal_editar_orden.php
@@ -11,7 +11,7 @@ if (!$orden) {
 ?>
 
 <form id="formEditarOrden">
-  <input type="hidden" name="id" value="<?= $orden['id'] ?>">
+  <input type="hidden" name="id" value="<?= htmlspecialchars($orden['id'], ENT_QUOTES, 'UTF-8') ?>">
   <div class="modal-header">
     <h5 class="modal-title">Editar Orden de Compra</h5>
     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
@@ -35,12 +35,12 @@ if (!$orden) {
 
     <div class="mb-3">
       <label class="form-label">Monto</label>
-      <input type="number" name="monto" class="form-control" value="<?= $orden['monto'] ?>" required min="0" step="0.01">
+      <input type="number" name="monto" class="form-control" value="<?= htmlspecialchars($orden['monto'], ENT_QUOTES, 'UTF-8') ?>" required min="0" step="0.01">
     </div>
 
     <div class="mb-3">
       <label class="form-label">Fecha de Pago</label>
-      <input type="date" name="fecha_pago" class="form-control" value="<?= $orden['fecha_pago'] ?>" required>
+      <input type="date" name="fecha_pago" class="form-control" value="<?= htmlspecialchars($orden['fecha_pago'], ENT_QUOTES, 'UTF-8') ?>" required>
     </div>
 
     <div class="mb-3">


### PR DESCRIPTION
## Summary
- sanitize PanelResumen output
- escape labels in KPI charts
- sanitize KPI printable card labels
- escape modal values and file paths

## Testing
- `php -l app/components/PanelResumen.php`
- `php -l kpis.php`
- `php -l kpis_mantenimiento_printable.php`
- `php -l kpis_servicio_cliente_printable.php`
- `php -l modal_comprobantes.php`
- `php -l modal_editar_orden.php`


------
https://chatgpt.com/codex/tasks/task_e_6882abd965748332ac26886492835a21