### PR TITLE
Refactor gastos modals using FormularioBase

### DIFF
--- a/app/components/FormularioBase.php
+++ b/app/components/FormularioBase.php
@@ -25,6 +25,8 @@ class FormularioBase {
             $required   = !empty($field['required']) ? 'required' : '';
             $validation = $field['validation'] ?? '';
             $id         = $field['id'] ?? $name;
+            $class      = $field['class'] ?? ($type === 'select' ? 'form-select' : 'form-control');
+            $attrs      = $field['attrs'] ?? '';
 
             $html .= "<div class=\"mb-3\">";
             if ($label) {
@@ -33,7 +35,7 @@ class FormularioBase {
 
             switch ($type) {
                 case 'select':
-                    $html .= "<select name=\"{$name}\" id=\"{$id}\" class=\"form-select\" {$required}>";
+                    $html .= "<select name=\"{$name}\" id=\"{$id}\" class=\"{$class}\" {$required} {$attrs}>";
                     $html .= '<option value="">Seleccionar</option>';
                     foreach ($options as $optValue => $optLabel) {
                         $selected = ((string)$optValue === (string)$value) ? 'selected' : '';
@@ -46,12 +48,12 @@ class FormularioBase {
 
                 case 'textarea':
                     $valEsc = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
-                    $html .= "<textarea name=\"{$name}\" id=\"{$id}\" class=\"form-control\" {$required}>{$valEsc}</textarea>";
+                    $html .= "<textarea name=\"{$name}\" id=\"{$id}\" class=\"{$class}\" {$required} {$attrs}>{$valEsc}</textarea>";
                     break;
 
                 default:
                     $valEsc = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
-                    $html .= "<input type=\"{$type}\" name=\"{$name}\" id=\"{$id}\" class=\"form-control\" value=\"{$valEsc}\" {$required}>";
+                    $html .= "<input type=\"{$type}\" name=\"{$name}\" id=\"{$id}\" class=\"{$class}\" value=\"{$valEsc}\" {$required} {$attrs}>";
                     break;
             }
 

--- a/app/modules/gastos/modal_editar_gasto.php
+++ b/app/modules/gastos/modal_editar_gasto.php
@@ -1,98 +1,64 @@
 <?php
 include 'conexion.php';
+require_once __DIR__.'/../../components/FormularioBase.php';
 
 $id = intval($_GET['id'] ?? 0);
 $gasto = $conn->query("SELECT * FROM gastos WHERE id = $id")->fetch_assoc();
-
-if (!$gasto) {
+if(!$gasto){
     echo "<div class='p-3 text-danger'>Gasto no encontrado.</div>";
     exit;
 }
-?>
 
+$optsProv = [];
+$res = $conn->query("SELECT id,nombre FROM proveedores ORDER BY nombre");
+while($row = $res->fetch_assoc()) $optsProv[$row['id']] = $row['nombre'];
+
+$optsUnidades = [];
+$res = $conn->query("SELECT id,nombre FROM unidades_negocio ORDER BY nombre");
+while($row = $res->fetch_assoc()) $optsUnidades[$row['id']] = $row['nombre'];
+
+$campos = [
+    ['type'=>'hidden','name'=>'id','default'=>$gasto['id']],
+    ['type'=>'select','name'=>'proveedor_id','label'=>'Proveedor','options'=>$optsProv,'default'=>$gasto['proveedor_id'],'required'=>true,'class'=>'form-select select2'],
+    ['type'=>'number','name'=>'monto','label'=>'Monto','default'=>$gasto['monto'],'required'=>true,'attrs'=>'min="0" step="0.01"'],
+    ['type'=>'date','name'=>'fecha_pago','label'=>'Fecha de Pago','default'=>$gasto['fecha_pago'],'required'=>true],
+    ['type'=>'select','name'=>'unidad_negocio_id','label'=>'Unidad de Negocio','options'=>$optsUnidades,'default'=>$gasto['unidad_negocio_id'],'required'=>true,'class'=>'form-select select2']
+];
+?>
 <form id="formEditarGasto" action="app/modules/gastos/actualizar_gasto.php" method="POST">
-  <input type="hidden" name="id" value="<?= $gasto['id'] ?>">
   <div class="modal-header">
     <h5 class="modal-title">Editar Gasto</h5>
     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
   </div>
   <div class="modal-body">
-
-    <div class="mb-3">
-      <label class="form-label">Proveedor</label>
-      <select name="proveedor_id" class="form-select select2" required>
-        <option value="">Seleccione proveedor</option>
-        <?php
-        $prov = $conn->query("SELECT id, nombre FROM proveedores ORDER BY nombre");
-        while ($p = $prov->fetch_assoc()):
-        ?>
-        <option value="<?= $p['id'] ?>" <?= $p['id'] == $gasto['proveedor_id'] ? 'selected' : '' ?>>
-          <?= htmlspecialchars($p['nombre']) ?>
-        </option>
-        <?php endwhile; ?>
-      </select>
-    </div>
-
-    <div class="mb-3">
-      <label class="form-label">Monto</label>
-      <input type="number" name="monto" class="form-control" value="<?= $gasto['monto'] ?>" required min="0" step="0.01">
-    </div>
-
-    <div class="mb-3">
-      <label class="form-label">Fecha de Pago</label>
-      <input type="date" name="fecha_pago" class="form-control" value="<?= $gasto['fecha_pago'] ?>" required>
-    </div>
-
-    <div class="mb-3">
-      <label class="form-label">Unidad de Negocio</label>
-      <select name="unidad_negocio_id" class="form-select" required>
-        <option value="">Seleccione unidad</option>
-        <?php
-        $unidades = $conn->query("SELECT id, nombre FROM unidades_negocio ORDER BY nombre");
-        while ($u = $unidades->fetch_assoc()):
-        ?>
-        <option value="<?= $u['id'] ?>" <?= $u['id'] == $gasto['unidad_negocio_id'] ? 'selected' : '' ?>>
-          <?= htmlspecialchars($u['nombre']) ?>
-        </option>
-        <?php endwhile; ?>
-      </select>
-    </div>
-
+    <?= FormularioBase::render($campos) ?>
     <input type="hidden" name="origen" value="Directo">
     <input type="hidden" name="tipo_gasto" value="Unico">
-
   </div>
   <div class="modal-footer">
-    <button type="submit" class="btn btn-warning">Actualizar Gasto</button>
+    <button type="submit" class="btn btn-warning w-100">Actualizar Gasto</button>
   </div>
 </form>
 <script>
-document.addEventListener("DOMContentLoaded", function () {
-  const form = document.getElementById("formEditarGasto");
-  if (!form) return;
+$(function(){
+  const modal = $('#modalEditarGasto');
+  $('.select2').select2({width:'100%', dropdownParent: modal});
 
-  form.addEventListener("submit", function (e) {
+  $('#formEditarGasto').on('submit', function(e){
     e.preventDefault();
-
-    const datos = new FormData(form);
-
-    fetch(form.action + '?ajax=1', {
-      method: form.method,
-      body: datos
-    })
-    .then(res => res.text())
-    .then(respuesta => {
-      if (respuesta.trim() === "ok") {
-        alert("✅ Gasto actualizado correctamente");
-        const modal = bootstrap.Modal.getInstance(form.closest(".modal"));
-        if (modal) modal.hide();
-
-        if(window.refreshModule) window.refreshModule();
-      } else {
-        alert("❌ Error: " + respuesta);
-      }
-    })
-    .catch(() => alert("❌ Error de conexión"));
+    const datos = new FormData(this);
+    fetch(this.action + '?ajax=1', { method: this.method, body: datos })
+      .then(r=>r.text())
+      .then(t=>{
+        if(t.trim()==='ok'){
+          alert('✅ Gasto actualizado correctamente');
+          bootstrap.Modal.getInstance(modal[0]).hide();
+          if(window.refreshModule) window.refreshModule();
+        }else{
+          alert('❌ Error: '+t);
+        }
+      })
+      .catch(()=> alert('❌ Error de conexión'));
   });
 });
 </script>

--- a/app/modules/gastos/view.php
+++ b/app/modules/gastos/view.php
@@ -71,9 +71,7 @@ class IncludeModal extends ModalBase {
     }
 }
 
-$modalNuevo  = new IncludeModal('modalGasto', __DIR__.'/modal_gasto.php');
 $modalOrden  = new IncludeModal('modalOrden', __DIR__.'/../../modal_orden.php');
-$modalEditar = new IncludeModal('modalEditarGasto', __DIR__.'/modal_editar_gasto.php');
 $modalAbono  = new IncludeModal('modalAbono', __DIR__.'/modal_abono.php');
 $modalComp   = new IncludeModal('modalComprobantes', __DIR__.'/../../modal_comprobantes.php');
 $modalKpis   = new IncludeModal('modalKpisGastos', __DIR__.'/../../includes/modals/modal_kpis_gastos.php');
@@ -89,6 +87,7 @@ $modalKpis   = new IncludeModal('modalKpisGastos', __DIR__.'/../../includes/moda
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/js/select2.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="assets/js/modales.js"></script>
 </head>
 <body class="bg-light">
 <?php endif; ?>
@@ -196,10 +195,14 @@ $modalKpis   = new IncludeModal('modalKpisGastos', __DIR__.'/../../includes/moda
     </table>
     </div>
 </div>
+<div class="modal fade" id="modalGasto" data-modal-url="app/modules/gastos/modal_gasto.php?ajax=1" tabindex="-1">
+  <div class="modal-dialog"><div class="modal-content">Cargando...</div></div>
+</div>
+<div class="modal fade" id="modalEditarGasto" tabindex="-1">
+  <div class="modal-dialog"><div class="modal-content">Cargando...</div></div>
+</div>
 <?php
-$modalNuevo->show();
 $modalOrden->show();
-$modalEditar->show();
 $modalAbono->show();
 $modalComp->show();
 $modalKpis->show();
@@ -208,14 +211,12 @@ $modalKpis->show();
 document.addEventListener('DOMContentLoaded', () => {
     $('.select2').select2({width:'100%'});
 });
+const modalEditar = document.getElementById('modalEditarGasto');
 document.querySelectorAll('.edit-btn').forEach(btn => {
     btn.addEventListener('click', () => {
         const id = btn.dataset.id;
-        fetch('app/modules/gastos/modal_editar_gasto.php?id=' + id + '&ajax=1')
-            .then(r => r.text())
-            .then(html => {
-                document.querySelector('#modalEditarGasto .modal-content').innerHTML = html;
-            });
+        modalEditar.setAttribute('data-modal-url', 'app/modules/gastos/modal_editar_gasto.php?id=' + id + '&ajax=1');
+        bootstrap.Modal.getOrCreateInstance(modalEditar).show();
     });
 });
 


### PR DESCRIPTION
## Summary
- extend `FormularioBase` to allow classes and extra attributes
- rewrite `modal_gasto.php` and `modal_editar_gasto.php` to build fields arrays
- load forms dynamically via data-modal-url in `view.php`
- adjust edit button JS to open modal with fetch
- include `assets/js/modales.js` in gastos view

## Testing
- `php -l app/components/FormularioBase.php`
- `php -l app/modules/gastos/modal_gasto.php`
- `php -l app/modules/gastos/modal_editar_gasto.php`
- `php -l app/modules/gastos/view.php`


------
https://chatgpt.com/codex/tasks/task_e_6883c4edab088332b455aa5c983ac337