### PR TITLE
Enable inline editing for gastos

### DIFF
--- a/app/modules/gastos/actualizar_campo_gasto.php
+++ b/app/modules/gastos/actualizar_campo_gasto.php
@@ -14,7 +14,7 @@ $id = isset($_POST['id']) ? intval($_POST['id']) : 0;
 $campo = $_POST['campo'] ?? '';
 $valor = $_POST['valor'] ?? '';
 
-$campos_permitidos = ['medio_pago', 'cuenta_bancaria', 'concepto', 'tipo_compra', 'estatus'];
+$campos_permitidos = ['medio_pago', 'cuenta_bancaria', 'concepto', 'tipo_compra', 'estatus', 'abonado_total', 'saldo', 'recibo'];
 
 if (!$id || !in_array($campo, $campos_permitidos)) {
     http_response_code(400);


### PR DESCRIPTION
## Summary
- allow editing of more fields in gastos view via `<input>` and `<select>`
- send updates on blur/change and highlight success or failure
- permit new fields in `actualizar_campo_gasto.php`

## Testing
- `php -l app/modules/gastos/view.php`
- `php -l app/modules/gastos/actualizar_campo_gasto.php`


------
https://chatgpt.com/codex/tasks/task_e_6883f88412f88332804c9872544ca2d4