### PR TITLE
Add form edit capabilities

### DIFF
--- a/app/components/FormularioBase.php
+++ b/app/components/FormularioBase.php
@@ -13,20 +13,28 @@ class FormularioBase {
      *   - required: bool para marcar como requerido
      *   - validation: mensaje de validación a mostrar
      */
-    public static function render(array $config): string {
+    public static function render(array $config, array $values = []): string {
         $html = '';
 
         foreach ($config as $field) {
-            $type       = $field['type'] ?? 'text';
-            $name       = $field['name'] ?? '';
-            $label      = $field['label'] ?? '';
-            $options    = $field['options'] ?? [];
-            $value      = $field['default'] ?? '';
+            $type    = $field['type'] ?? 'text';
+            $name    = $field['name'] ?? '';
+            $label   = $field['label'] ?? '';
+            $options = $field['options'] ?? [];
+
+            $value = $field['value'] ?? $field['default'] ?? ($name && isset($values[$name]) ? $values[$name] : '');
+
             $required   = !empty($field['required']) ? 'required' : '';
+            $readonly   = !empty($field['readonly']) ? 'readonly' : '';
+            $disabled   = !empty($field['disabled']) ? 'disabled' : '';
+            $placeholder = $field['placeholder'] ?? '';
             $validation = $field['validation'] ?? '';
             $id         = $field['id'] ?? $name;
             $class      = $field['class'] ?? ($type === 'select' ? 'form-select' : 'form-control');
-            $attrs      = $field['attrs'] ?? '';
+            $attrs      = trim($field['attrs'] ?? '');
+
+            $placeholderAttr = $placeholder !== '' ? 'placeholder="' . htmlspecialchars($placeholder, ENT_QUOTES, 'UTF-8') . '"' : '';
+            $attrStr = trim(implode(' ', array_filter([$required, $readonly, $disabled, $placeholderAttr, $attrs])));
 
             $html .= "<div class=\"mb-3\">";
             if ($label) {
@@ -35,7 +43,7 @@ class FormularioBase {
 
             switch ($type) {
                 case 'select':
-                    $html .= "<select name=\"{$name}\" id=\"{$id}\" class=\"{$class}\" {$required} {$attrs}>";
+                    $html .= "<select name=\"{$name}\" id=\"{$id}\" class=\"{$class}\" {$attrStr}>";
                     $html .= '<option value="">Seleccionar</option>';
                     foreach ($options as $optValue => $optLabel) {
                         $selected = ((string)$optValue === (string)$value) ? 'selected' : '';
@@ -48,12 +56,12 @@ class FormularioBase {
 
                 case 'textarea':
                     $valEsc = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
-                    $html .= "<textarea name=\"{$name}\" id=\"{$id}\" class=\"{$class}\" {$required} {$attrs}>{$valEsc}</textarea>";
+                    $html .= "<textarea name=\"{$name}\" id=\"{$id}\" class=\"{$class}\" {$attrStr}>{$valEsc}</textarea>";
                     break;
 
                 default:
                     $valEsc = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
-                    $html .= "<input type=\"{$type}\" name=\"{$name}\" id=\"{$id}\" class=\"{$class}\" value=\"{$valEsc}\" {$required} {$attrs}>";
+                    $html .= "<input type=\"{$type}\" name=\"{$name}\" id=\"{$id}\" class=\"{$class}\" value=\"{$valEsc}\" {$attrStr}>";
                     break;
             }
 

--- a/app/modules/gastos/modal_editar_gasto.php
+++ b/app/modules/gastos/modal_editar_gasto.php
@@ -18,11 +18,11 @@ $res = $conn->query("SELECT id,nombre FROM unidades_negocio ORDER BY nombre");
 while($row = $res->fetch_assoc()) $optsUnidades[$row['id']] = $row['nombre'];
 
 $campos = [
-    ['type'=>'hidden','name'=>'id','default'=>$gasto['id']],
-    ['type'=>'select','name'=>'proveedor_id','label'=>'Proveedor','options'=>$optsProv,'default'=>$gasto['proveedor_id'],'required'=>true,'class'=>'form-select select2'],
-    ['type'=>'number','name'=>'monto','label'=>'Monto','default'=>$gasto['monto'],'required'=>true,'attrs'=>'min="0" step="0.01"'],
-    ['type'=>'date','name'=>'fecha_pago','label'=>'Fecha de Pago','default'=>$gasto['fecha_pago'],'required'=>true],
-    ['type'=>'select','name'=>'unidad_negocio_id','label'=>'Unidad de Negocio','options'=>$optsUnidades,'default'=>$gasto['unidad_negocio_id'],'required'=>true,'class'=>'form-select select2']
+    ['type'=>'hidden','name'=>'id'],
+    ['type'=>'select','name'=>'proveedor_id','label'=>'Proveedor','options'=>$optsProv,'required'=>true,'class'=>'form-select select2'],
+    ['type'=>'number','name'=>'monto','label'=>'Monto','required'=>true,'attrs'=>'min="0" step="0.01"'],
+    ['type'=>'date','name'=>'fecha_pago','label'=>'Fecha de Pago','required'=>true],
+    ['type'=>'select','name'=>'unidad_negocio_id','label'=>'Unidad de Negocio','options'=>$optsUnidades,'required'=>true,'class'=>'form-select select2']
 ];
 ?>
 <form id="formEditarGasto" action="app/modules/gastos/actualizar_gasto.php" method="POST">
@@ -31,7 +31,7 @@ $campos = [
     <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
   </div>
   <div class="modal-body">
-    <?= FormularioBase::render($campos) ?>
+    <?= FormularioBase::render($campos, $gasto) ?>
     <input type="hidden" name="origen" value="Directo">
     <input type="hidden" name="tipo_gasto" value="Unico">
   </div>


### PR DESCRIPTION
## Summary
- enhance `FormularioBase` to accept values and read-only attributes
- allow specifying defaults when editing records
- update gastos edit modal to use the new helper

## Testing
- `php -l app/components/FormularioBase.php`
- `php -l app/modules/gastos/modal_editar_gasto.php`


------
https://chatgpt.com/codex/tasks/task_e_6883fcbe537c8332b8b0f6d394dade41